### PR TITLE
Stop PCSX2's duplicate frame setting from halving the framerate

### DIFF
--- a/android/armsx3-ui/app/src/main/java/com/armsx3/Rpcs3Bridge.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx3/Rpcs3Bridge.kt
@@ -335,7 +335,20 @@ object Rpcs3Bridge {
                     if (asBool(value)) Rpcs3Settings.setFrameLimitMode("Display")
                 "VsyncEnable" -> Rpcs3Settings.setVsync(asBool(value))
                 "MaxAnisotropy" -> Rpcs3Settings.setAnisotropicFilter(asInt(value))
-                "SkipDuplicateFrames" -> Rpcs3Settings.setFrameSkip(if (asBool(value)) 1 else 0)
+                // PCSX2's "skip duplicate frames" means "do not present a frame identical to
+                // the last one". It is harmless there and on by default, which is why Settings
+                // defaults it to true. RPCS3 has no equivalent, and this used to map onto
+                // Enable Frame Skip, which means something else entirely: drop one frame in
+                // every two, unconditionally. Every title therefore presented at half the rate
+                // the guest asked for, out of the box, on a fresh install.
+                //
+                // It also made the frameskip row inert, since applyToInner pushes the explicit
+                // frameskip first and this key afterwards, so this one always won. Measured on
+                // Mirror's Edge: the guest asks for 30 flips/s, SurfaceFlinger presented 15.0.
+                //
+                // Dropped rather than remapped. Frameskip belongs to the explicit control,
+                // which is the one the user actually set.
+                "SkipDuplicateFrames" -> return true
                 "DisableShaderCache" -> Rpcs3Settings.setDisableShaderCache(asBool(value))
                 "IntegerScaling" ->
                     // Nearest-neighbour is the closest RPCS3 has to integer scaling;


### PR DESCRIPTION
SkipDuplicateFrames in PCSX2 means "do not present a frame identical to the last one". It is harmless there and on by default, which is why Settings defaults it to true. RPCS3 has no equivalent, and the bridge mapped it onto Enable Frame Skip, which means something completely different: drop one frame in every two, unconditionally.

So every game presented at half the rate the guest asked for, on a fresh install, with nothing touched. It also made the frameskip row in the in-game menu useless, because applyToInner pushes the explicit frameskip first and this key afterwards, so this one always won no matter what you picked.

Measured on Mirror's Edge, which asks for 30 flips a second. SurfaceFlinger was presenting 15.0 fps, one frame every 66.65 ms, rock steady. The RSX thread reported 0-5% load with six of eight cores idle, which is what sent me looking for a performance problem that was never there. With the mapping gone it sits at 30.0 fps, 33.32 ms.

Dropped rather than remapped. Frameskip belongs to the explicit control, which is the one the user actually set.