### PR TITLE
Unmap guest memory when precompilation finishes

### DIFF
--- a/android/src/rpcsx-android.cpp
+++ b/android/src/rpcsx-android.cpp
@@ -1540,6 +1540,20 @@ private:
 
     rpcsx_android.error("Finalization");
     g_fxo->reset();
+
+    // Pairs with the vm::init() above. Nothing else unmaps it, since vm::close()
+    // is only reached from Emu.Stop() and precompilation never boots, so the
+    // blocks this pass mapped outlive it and stay valid.
+    //
+    // The next vm::init(), either the next workload or Emulator::Load() booting
+    // a game, assigns over g_locations. That destroys blocks that are still
+    // valid and aborts the process in ~block_t()'s ensure(!is_valid()).
+    //
+    // Has to come after g_fxo->reset(): vm::close() requires each block to be
+    // uniquely owned, and _unmap_block throws "External memory usage at block"
+    // if anything still holds one of its shm references.
+    vm::close();
+
     Emu.SetState(system_state::stopped);
 
     MessageDialog::popPendingProgressId(workload.progressId);


### PR DESCRIPTION
The precompilation queue calls vm::init() so that ppu_register_range has somewhere to register, but nothing ever unmapped it again. vm::close() is only reached from Emu.Stop(), and precompilation deliberately never boots anything.

So the blocks stayed mapped past "Finalization". The next vm::init(), either the next workload or Emulator::Load() booting a game, assigns over g_locations and destroys them, which trips ensure(!is_valid()) in ~block_t() and takes the whole process down.

Easy to reproduce: install firmware and then boot a game without restarting the app. The firmware pass leaves five live blocks behind and the boot dies inside vm::ps3_::init() before it reads a byte of the disc.