### PR TITLE
Don't let the OSD mode switch the performance overlay off at boot

### DIFF
--- a/android/armsx3-ui/app/src/main/java/com/armsx2/ui/InGameOverlay.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/ui/InGameOverlay.kt
@@ -211,6 +211,16 @@ object InGameOverlay {
             s.osdShowVersion, s.osdShowSettings, s.osdShowInputs,
         )
         NativeApp.osdShowGpuStats(s.osdShowGpuStats)
+        // RPCS3 has a Performance Overlay switch of its own (OverlayTab and the in-game menu,
+        // both writing ps3.overlayEnabled) on top of ARMSX2's twelve per-stat flags. They drive
+        // the same core node, and osdApplyFlags derives it purely from the twelve, all of which
+        // default to off, so it pushed Enabled=false straight over the switch. Boot order gave
+        // it the last word: MainActivityRuntime calls applyTo() and then applyStoredOsdMode().
+        // The switch was therefore inert, and only that one key was affected, because
+        // osdApplyFlags returns early when nothing is on and never reaches the graph settings.
+        if (s.ps3.overlayEnabled) {
+            com.armsx3.Rpcs3Settings.setOverlayEnabled(true)
+        }
     }
 
     fun editTouchLayout() {


### PR DESCRIPTION
Two things end up writing the same config node. RPCS3 has its own Performance Overlay switch, in OverlayTab and the in-game menu, both writing ps3.overlayEnabled. ARMSX2 has its twelve per-stat osdShow* flags, and osdApplyFlags derives Enabled purely from those, all of which default to off. So it pushed Enabled=false right over the switch.

Boot order decided the winner. MainActivityRuntime calls applyTo(), which pushes the switch, and then applyStoredOsdMode() one line later, which pushes the flags. Turning the overlay on in settings did nothing at all.

Only that one key was affected, because osdApplyFlags returns as soon as it sees nothing enabled and never reaches the graph, font size and opacity settings. That is why config.yml held the user's values for those while Enabled sat at false.

Re-assert the switch after the flags have been applied. Scoped to the Custom path, since that is the mode that reads saved settings and the one that runs at boot. Full and Min pass explicit flags, and Off is meant to be off.