### PR TITLE
Fix console aspect ratio Auto resolving to 4:3

### DIFF
--- a/android/armsx3-ui/app/src/main/java/com/armsx3/NativeApp.java
+++ b/android/armsx3-ui/app/src/main/java/com/armsx3/NativeApp.java
@@ -315,16 +315,24 @@ public final class NativeApp {
     public static void setPreferVulkan(boolean e) { /* Vulkan is the only backend */ }
 
     /**
-     * [MAPPED] ARMSX2's aspect enum: 0 = stretch/native, 1 = 4:3, 2 = 16:9.
+     * [MAPPED] The console aspect index the UI stores, which is RendererTab's
+     * picker: 0 = stretch, 1 = Auto, 2 = 4:3, 3 = 16:9, 4..8 = the ultrawide
+     * ratios ARMSX2 offered.
+     *
      * RPCS3 only has 4:3 and 16:9 plus a separate "Stretch To Display Area"
-     * flag, so mode 0 maps to the flag rather than a third enum value.
+     * flag, so index 0 maps to the flag rather than a third enum value, and
+     * everything that is not 4:3 lands on 16:9.
+     *
+     * The doc here used to describe ARMSX2's PS2 enum, where 1 was 4:3, and the
+     * check below was written against it. ARMSX3's picker inserted Auto at 1 and
+     * pushed 4:3 to 2, so Auto was resolving to 4:3.
      */
     public static void setAspectRatio(int type) {
         if (type == 0) {
             Rpcs3Settings.INSTANCE.setStretchToDisplay(true);
         } else {
             Rpcs3Settings.INSTANCE.setStretchToDisplay(false);
-            Rpcs3Settings.INSTANCE.setAspectRatio(type != 1);
+            Rpcs3Settings.INSTANCE.setAspectRatio(type != 2);
         }
     }
 


### PR DESCRIPTION
Closes #3.

setAspectRatio was written against ARMSX2's PS2 aspect enum, where index 1 was 4:3, and its javadoc still described that enum. ARMSX3's picker in RendererTab is a different one: 0 stretch, 1 Auto, 2 is 4:3 and 3 is 16:9. So the check for index 1 was matching Auto, and Auto is the default.

Every game therefore came up in 4:3 on a fresh install, and RPCS3's own default for that node is 16:9. Setting the picker to 16:9 by hand worked, which is what the issue reports, because index 3 fell through to the 16:9 branch.

Compare against index 2 instead, so only an explicit 4:3 selects 4:3 and everything else lands on 16:9. That also lines it up with the other writer of this node, writeGsToNative, which maps the same indices by name and already treated anything other than "4:3" as widescreen.

Verified on an Odin 3: config.yml went from "Aspect ratio: 4:3" to "Aspect ratio: 16:9" with the picker left on Auto.