### PR TITLE
Make the Scaling Mode row actually pick the scaling mode

### DIFF
--- a/android/armsx3-ui/app/src/main/java/com/armsx2/config/Settings.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/config/Settings.kt
@@ -723,7 +723,9 @@ data class Settings(
      *  No EmuCore key mirrors this — see applyTo. */
     val shaderChainParams: Map<String, Map<String, Float>> = emptyMap(),
     /** EmuCore/GS/CASMode — GSCASMode: 0 Off / 1 Sharpen Only / 2 Sharpen + Resize. */
-    val casMode: Int = 0,
+    /** Scaling Mode row: 0 Nearest, 1 Bilinear, 2 FSR. Bilinear because that is what the
+     *  core has always actually used, and what RPCS3 itself defaults to. */
+    val casMode: Int = 1,
     /** EmuCore/GS/CASSharpness — sharpening strength 0..100 (%). */
     val casSharpness: Int = 50,
     /** EmuCore/GS/LoadTextureReplacements. */
@@ -1601,6 +1603,10 @@ data class Settings(
         put("EmuCore/GS", "ShadeBoost_Saturation", "int", shadeBoostSaturation.coerceIn(1, 100).toString())
         put("EmuCore/GS", "ShadeBoost_Gamma", "int", shadeBoostGamma.coerceIn(1, 100).toString())
         put("EmuCore/GS", "fxaa", "bool", fxaa.toString())
+        // Scaling Mode writes Output Scaling Mode unconditionally, the shader chain only
+        // when it is on, so CAS has to go first for the chain to keep the last word.
+        put("EmuCore/GS", "CASMode", "int", casMode.coerceIn(0, 2).toString())
+        put("EmuCore/GS", "CASSharpness", "int", casSharpness.coerceIn(0, 100).toString())
         put("EmuCore/GS", "ShaderChainEnabled", "bool", shaderChainEnabled.toString())
         put("EmuCore/GS", "ShaderChainPreset", "string", shaderChainPreset)
         // Parameter overrides, as one opaque JSON blob. Nothing in emucore reads this key —
@@ -1617,8 +1623,6 @@ data class Settings(
         // Skipped under emitSink: an export has no renderer to push to.
         if (emitSink == null)
             ShaderParams.push(shaderChainPreset, shaderChainParams[shaderChainPreset].orEmpty())
-        put("EmuCore/GS", "CASMode", "int", casMode.coerceIn(0, 2).toString())
-        put("EmuCore/GS", "CASSharpness", "int", casSharpness.coerceIn(0, 100).toString())
         put("EmuCore/GS", "LoadTextureReplacements", "bool", loadTextureReplacements.toString())
         put("EmuCore/GS", "LoadTextureReplacementsAsync", "bool", loadTextureReplacementsAsync.toString())
         put("EmuCore/GS", "PrecacheTextureReplacements", "bool", precacheTextureReplacements.toString())

--- a/android/armsx3-ui/app/src/main/java/com/armsx3/Rpcs3Bridge.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx3/Rpcs3Bridge.kt
@@ -337,17 +337,29 @@ object Rpcs3Bridge {
                 "MaxAnisotropy" -> Rpcs3Settings.setAnisotropicFilter(asInt(value))
                 "SkipDuplicateFrames" -> Rpcs3Settings.setFrameSkip(if (asBool(value)) 1 else 0)
                 "DisableShaderCache" -> Rpcs3Settings.setDisableShaderCache(asBool(value))
-                "IntegerScaling" ->
-                    // Nearest-neighbour is the closest RPCS3 has to integer scaling;
-                    // bilinear otherwise. Overridden below if CAS/librashader is on.
-                    Rpcs3Settings.setOutputScaling(if (asBool(value)) "Nearest" else "Bilinear")
-                "linear_present_mode" ->
-                    Rpcs3Settings.setOutputScaling(if (asInt(value) == 0) "Nearest" else "Bilinear")
-                // CAS and the librashader chain are both OUTPUT SCALING MODES in
-                // RPCS3, not independent post-effects, so enabling either has to
-                // claim the mode. Shader chain wins -- it is the more specific ask.
-                "CASMode" ->
-                    if (asInt(value) > 0) Rpcs3Settings.setOutputScaling("FidelityFX Super Resolution")
+                // Four keys used to write Output Scaling Mode, and the two with no UI behind
+                // them were winning. IntegerScaling and linear_present_mode are PCSX2 keys that
+                // no screen in this app exposes, and both wrote the node unconditionally, with
+                // IntegerScaling emitted last. So whatever the visible Scaling Mode row asked
+                // for was overwritten a moment later.
+                //
+                // They own nothing the user can see, so they no longer write it at all.
+                "IntegerScaling" -> return true
+                "linear_present_mode" -> return true
+                // This is the visible Scaling Mode row in RendererTab: Nearest, Bilinear, FSR.
+                // It used to be read as PCSX2's CAS mode, where anything above zero meant "CAS
+                // on", so picking Bilinear asked for FSR and picking Nearest asked for nothing.
+                // Map the row's own indices instead.
+                //
+                // Writes unconditionally, so it has to be emitted before ShaderChainEnabled for
+                // the chain to keep the last word, which is what applyToInner now does.
+                "CASMode" -> Rpcs3Settings.setOutputScaling(
+                    when (asInt(value)) {
+                        0 -> "Nearest"
+                        2 -> "FidelityFX Super Resolution"
+                        else -> "Bilinear"
+                    },
+                )
                 "CASSharpness" -> Rpcs3Settings.setCasSharpening(asInt(value))
                 "ShaderChainEnabled" ->
                     if (asBool(value)) Rpcs3Settings.setOutputScaling("Shader chain (librashader)")


### PR DESCRIPTION
Four keys were writing Output Scaling Mode and the two with nothing behind them were winning. IntegerScaling and linear_present_mode are PCSX2 keys that no screen in this app exposes, both wrote the node unconditionally, and IntegerScaling was emitted last, so it overwrote whatever the visible Scaling Mode row had asked for.

On top of that the row itself was misread. It offers Nearest, Bilinear and FSR and stores the index in casMode, but the bridge treated casMode as PCSX2's CAS mode, where anything above zero means "CAS on". So picking Bilinear asked for FSR, picking Nearest asked for nothing, and none of it survived anyway.

The two invisible keys no longer touch the node, and CASMode maps its own indices. CAS is emitted before ShaderChainEnabled now so the chain still gets the last word when both are on, which is what the bridge already documented.

casMode defaults to Bilinear rather than Nearest. Bilinear is what the core has been using all along, and what RPCS3 itself defaults to, so nobody's picture changes. Leaving the default at 0 would have quietly switched every user to nearest neighbour the moment the mapping started working.

Checked on an Odin 3, reading Output Scaling Mode back out of config.yml: picking FSR now gives FidelityFX Super Resolution where it used to give Bilinear, and picking Bilinear gives Bilinear for the right reason.