### PR TITLE
Serialize LLVM compilation of identical SPU programs

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -1652,14 +1652,65 @@ public:
 
 		if (func.entry_point != start0)
 		{
-			// Wait for the duplicate
+			// Wait for the duplicate. The result may be published either by the LLVM
+			// owner of this item or by spu_fast from the asmjit path, so wait on
+			// `compiled` itself, and additionally observe the LLVM failure state so an
+			// owner that bails out cannot strand these waiters. The timeout bounds the
+			// window in which a failure transition could be missed between the state
+			// check and going to sleep (the two are separate atomics).
 			while (!add_loc->compiled)
 			{
-				add_loc->compiled.wait(nullptr);
+				if (add_loc->llvm_compile_state == 3)
+				{
+					return nullptr;
+				}
+
+				add_loc->compiled.wait(nullptr, atomic_wait_timeout{10'000'000});
 			}
 
 			return add_loc->compiled;
 		}
+
+		// Claim LLVM compilation of this item (see llvm_compile_state in spu_item).
+		// Late arrivals wait for the owner instead of compiling the same program
+		// again: the duplicate compile raced `compiled` publication and trampoline
+		// rebuilds (wedging SPURS bring-up on cold boots), and made up the majority
+		// of cold compilation work.
+		if (add_loc->llvm_compile_state.compare_and_swap(0, 1) != 0)
+		{
+			while (add_loc->llvm_compile_state == 1)
+			{
+				add_loc->llvm_compile_state.wait(1);
+			}
+
+			if (add_loc->llvm_compile_state == 2)
+			{
+				return add_loc->compiled;
+			}
+
+			// Owner failed (emulator stopping)
+			return nullptr;
+		}
+
+		// Ensure waiters are released on every exit path: any return that leaves the
+		// state at "compiling" is a failure and must not strand them.
+		struct claim_guard_t
+		{
+			spu_item* item;
+
+			~claim_guard_t()
+			{
+				if (item && item->llvm_compile_state == 1)
+				{
+					item->llvm_compile_state.release(3);
+					item->llvm_compile_state.notify_all();
+
+					// Also wake threads sleeping on `compiled` (the relocated-duplicate
+					// wait above); they re-check the failure state on wakeup.
+					item->compiled.notify_all();
+				}
+			}
+		} claim_guard{add_loc};
 
 		bool add_to_file = false;
 
@@ -3981,6 +4032,10 @@ public:
 		}
 
 		add_loc->compiled.notify_all();
+
+		// Function is published; mark compilation complete and release claim waiters.
+		add_loc->llvm_compile_state.release(2);
+		add_loc->llvm_compile_state.notify_all();
 
 		if (g_cfg.core.spu_debug)
 		{

--- a/rpcs3/Emu/Cell/SPURecompiler.h
+++ b/rpcs3/Emu/Cell/SPURecompiler.h
@@ -91,6 +91,22 @@ public:
 	atomic_t<u8> cached = false;
 	atomic_t<u8> logged = false;
 
+	// LLVM compilation ownership for this item.
+	//
+	// add_empty() returns an existing item when an identical program is re-registered,
+	// and the entry-point dedup in spu_llvm_recompiler::compile() passes when the
+	// entry is also identical. Without this state, N SPU threads hitting the same
+	// uncached code at the same address all compile the same item concurrently with
+	// independent LLVM instances, racing the `compiled` publication and trampoline
+	// rebuilds (observed wedging SPURS bring-up on cold boots).
+	//
+	// 0 = unclaimed, 1 = compiling, 2 = complete, 3 = failed.
+	// The first LLVM compiler claims 0 -> 1; late arrivals wait while 1, then return
+	// `compiled` (or null on failure). An item pre-inserted by spu_fast is still
+	// claimable by the first LLVM worker, preserving the asynchronous optimized
+	// replacement path on x86-64. u32: atomic wait/notify needs a 32-bit type here.
+	atomic_t<u32> llvm_compile_state = 0;
+
 	spu_item(spu_program&& data)
 		: data(std::move(data))
 	{


### PR DESCRIPTION
Five SPURS kernel threads executing the same uncached code at the same
address all reached spu_llvm_recompiler::compile() for one spu_item.
add_empty() returns the existing item for an identical program without
telling the caller it did not insert, and the entry-point dedup only
catches equivalent code at a different address. Each thread then
compiled the program with its own LLVM instance, racing the compiled
pointer publication, the ubertrampoline rebuild, and the waiter
notification.

On my 8-core ARM64 device this wedged SPURS bring-up on every single
cold-cache boot of Virtua Tennis 4 (BLUS30529). The kernels ended up
parked polling zeroed workload state, the PPU main thread blocked
forever in sys_event_queue_receive on a queue no SPU would ever signal,
and the title never reached the menu. Warm boots never hit it because
cached programs are compiled before SPU execution starts, one
presentation per program. When I instrumented the compile path I saw up
to five concurrent compilations of a single item, around 790 collision
events per boot, with duplicates accounting for roughly two thirds of
all cold compilation work.

This change gives spu_item an explicit LLVM compilation state
(unclaimed, compiling, complete, failed). The first compiler claims the
item; later arrivals wait and take the published result, mirroring the
existing dedup-wait path. I made the claim a state on the item rather
than an inserted-flag from add_empty() so that an item pre-inserted by
spu_fast is still claimed by the first LLVM worker, which preserves the
asynchronous optimized replacement on x86-64. A scope guard marks the
item failed on any early exit so waiters cannot be stranded.

The pre-existing wait for relocated duplicates (same program, different
entry point) is also covered: it still waits on the compiled pointer,
because that result can be published by spu_fast from the asmjit path
which never touches the LLVM state, but it now observes the failure
state on each wakeup with a bounded timeout, and the failure guard
wakes those waiters too. Without this an owner that bailed out early
would have stranded them forever.

I verified this on device: 11 out of 11 cold boots stalled before the
change, 7 out of 7 pass after it, plus 2 out of 2 warm controls, and
Mirror's Edge now reaches gameplay past its previous SPURS stall.
Cold-boot SPU compilation dropped from about 12900 blocks to 3900.


**Reproduction for maintainers:** clear the compiled code cache (on Android: `cache/cache`, `ppu_progs`, `spu_progs` under the data folder), then cold boot Virtua Tennis 4 (BLUS30529). Without this change the boot stalls at the SPURS handshake every time, around four minutes in. With it the title reaches the menu on every attempt I made.
