### PR TITLE
Add missing ARM64 instruction-cache maintenance to the JIT

### DIFF
--- a/Utilities/JITASM.cpp
+++ b/Utilities/JITASM.cpp
@@ -250,6 +250,13 @@ void* jit_runtime_base::_add(asmjit::CodeHolder* code, usz align) noexcept
 		}
 	}
 
+#if defined(ARCH_ARM64)
+	// Instruction-cache maintenance for freshly copied code (trampolines, branch
+	// patchpoints). Nothing flushed these before; another core could fetch stale
+	// icache contents for this range.
+	asmjit::VirtMem::flushInstructionCache(p, codeSize);
+#endif
+
 	return p;
 }
 
@@ -326,16 +333,20 @@ void jit_runtime::finalize() noexcept
 	s_data_pos = 0;
 
 	// Restore code/data snapshot
-	std::memcpy(alloc(s_code_init.size(), 1, true), s_code_init.data(), s_code_init.size());
+	u8* const code_ptr = alloc(s_code_init.size(), 1, true);
+	std::memcpy(code_ptr, s_code_init.data(), s_code_init.size());
 	std::memcpy(alloc(s_data_init.size(), 1, false), s_data_init.data(), s_data_init.size());
 
 #ifdef __APPLE__
 	pthread_jit_write_protect_np(true);
 #endif
 #ifdef ARCH_ARM64
-	// Flush all cache lines after potentially writing executable code
-	asm("ISB");
-	asm("DSB ISH");
+	// The restored range is executable code rewritten in place: perform real
+	// instruction-cache maintenance for it (ISB/DSB alone cleans nothing).
+	if (code_ptr && !s_code_init.empty())
+	{
+		asmjit::VirtMem::flushInstructionCache(code_ptr, s_code_init.size());
+	}
 #endif
 }
 

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -238,6 +238,11 @@ struct MemoryManager1 : llvm::RTDyldMemoryManager
 	// May be a memory container internally
 	std::function<u64(const std::string&)> m_symbols_cement;
 
+#if defined(ARCH_ARM64)
+	// Code ranges allocated since the last finalizeMemory(), for icache maintenance
+	std::vector<std::pair<u8*, uptr>> m_code_ranges;
+#endif
+
 	MemoryManager1(std::function<u64(const std::string&)> symbols_cement = {}) noexcept
 		: m_symbols_cement(std::move(symbols_cement))
 	{
@@ -346,7 +351,17 @@ struct MemoryManager1 : llvm::RTDyldMemoryManager
 
 	u8* allocateCodeSection(uptr size, uint align, uint /*sec_id*/, llvm::StringRef /*sec_name*/) override
 	{
-		return allocate(code_ptr, m_code_mems, size, align, utils::protection::wx);
+		u8* const p = allocate(code_ptr, m_code_mems, size, align, utils::protection::wx);
+
+#if defined(ARCH_ARM64)
+		// Track for instruction-cache maintenance in finalizeMemory()
+		if (p)
+		{
+			m_code_ranges.emplace_back(p, size);
+		}
+#endif
+
+		return p;
 	}
 
 	u8* allocateDataSection(uptr size, uint align, uint /*sec_id*/, llvm::StringRef /*sec_name*/, bool is_ro) override
@@ -362,6 +377,16 @@ struct MemoryManager1 : llvm::RTDyldMemoryManager
 
 	bool finalizeMemory(std::string* = nullptr) override
 	{
+#if defined(ARCH_ARM64)
+		// See MemoryManager2::finalizeMemory(): RuntimeDyld relies on this callback
+		// for instruction-cache maintenance of freshly written code sections.
+		for (const auto& [p, size] : m_code_ranges)
+		{
+			asmjit::VirtMem::flushInstructionCache(p, size);
+		}
+
+		m_code_ranges.clear();
+#endif
 		return false;
 	}
 
@@ -380,6 +405,11 @@ struct MemoryManager2 : llvm::RTDyldMemoryManager
 	// First fallback for non-existing symbols
 	// May be a memory container internally
 	std::function<u64(const std::string&)> m_symbols_cement;
+
+#if defined(ARCH_ARM64)
+	// Code ranges allocated since the last finalizeMemory(), for icache maintenance
+	std::vector<std::pair<u8*, uptr>> m_code_ranges;
+#endif
 
 	MemoryManager2(std::function<u64(const std::string&)> symbols_cement = {}) noexcept
 		: m_symbols_cement(std::move(symbols_cement))
@@ -414,7 +444,17 @@ struct MemoryManager2 : llvm::RTDyldMemoryManager
 
 	u8* allocateCodeSection(uptr size, uint align, uint /*sec_id*/, llvm::StringRef /*sec_name*/) override
 	{
-		return jit_runtime::alloc(size, align, true);
+		u8* const p = jit_runtime::alloc(size, align, true);
+
+#if defined(ARCH_ARM64)
+		// Track for instruction-cache maintenance in finalizeMemory()
+		if (p)
+		{
+			m_code_ranges.emplace_back(p, size);
+		}
+#endif
+
+		return p;
 	}
 
 	u8* allocateDataSection(uptr size, uint align, uint /*sec_id*/, llvm::StringRef /*sec_name*/, bool /*is_ro*/) override
@@ -424,6 +464,19 @@ struct MemoryManager2 : llvm::RTDyldMemoryManager
 
 	bool finalizeMemory(std::string* = nullptr) override
 	{
+#if defined(ARCH_ARM64)
+		// RuntimeDyld calls finalizeMemory() after writing code and relies on it for
+		// instruction-cache maintenance. This was a no-op: freshly emitted code was
+		// never flushed, so other cores could execute stale icache contents for it.
+		// x86 has a coherent instruction cache and never noticed. The asmjit helper
+		// performs the required DC CVAU / IC IVAU broadcast sequence.
+		for (const auto& [p, size] : m_code_ranges)
+		{
+			asmjit::VirtMem::flushInstructionCache(p, size);
+		}
+
+		m_code_ranges.clear();
+#endif
 		return false;
 	}
 

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -1972,6 +1972,12 @@ spu_function_t spu_runtime::rebuild_ubertrampoline(u32 id_inst)
 		std::string fname;
 		fmt::append(fname, "__ub%u", m_flat_list.size());
 		jit_announce(wxptr, raw - wxptr, fname);
+
+#if defined(ARCH_ARM64)
+		// Flush the freshly written ubertrampoline BEFORE publishing it via the CAS
+		// below; other cores may branch into it immediately.
+		asmjit::VirtMem::flushInstructionCache(wxptr, raw - wxptr);
+#endif
 	}
 
 	if (auto _old = stuff_it->trampoline.compare_and_swap(nullptr, result))
@@ -2113,9 +2119,10 @@ spu_function_t spu_runtime::make_branch_patchpoint(u16 data) const
 	pthread_jit_write_protect_np(true);
 #endif
 
-	// Flush all cache lines after potentially writing executable code
-	asm("ISB");
-	asm("DSB ISH");
+	// ISB/DSB alone performs no D->I cache maintenance; the asmjit helper does the
+	// required DC CVAU + IC IVAU sequence (with trailing barriers) so other cores
+	// cannot fetch stale instructions for this freshly written patchpoint.
+	asmjit::VirtMem::flushInstructionCache(patch_fn, raw - patch_fn);
 
 	return reinterpret_cast<spu_function_t>(patch_fn);
 #else
@@ -2181,9 +2188,10 @@ void spu_recompiler_base::dispatch(spu_thread& spu, void*, u8* rip)
 		pthread_jit_write_protect_np(true);
 #endif
 
-		// Flush all cache lines after potentially writing executable code
-		asm("ISB");
-		asm("DSB ISH");
+		// ISB/DSB alone performs no D->I cache maintenance and is mis-ordered for
+		// self-modifying code; the asmjit helper does DC CVAU + IC IVAU (with
+		// trailing barriers) for the rewritten 16-byte branch site.
+		asmjit::VirtMem::flushInstructionCache(rip, 16);
 #else
 #error "Unimplemented"
 #endif
@@ -2329,9 +2337,9 @@ void spu_recompiler_base::branch(spu_thread& spu, void*, u8* rip)
 	pthread_jit_write_protect_np(true);
 #endif
 
-	// Flush all cache lines after potentially writing executable code
-	asm("ISB");
-	asm("DSB ISH");
+	// See the matching site above: real icache maintenance for the rewritten
+	// 16-byte branch site.
+	asmjit::VirtMem::flushInstructionCache(rip, 16);
 #else
 #error "Unimplemented"
 #endif


### PR DESCRIPTION
While chasing an unrelated SPURS hang I noticed the JIT publishes
freshly written code on ARM64 with no instruction-cache maintenance at
all. A grep for clear_cache or flushInstructionCache over the JIT layer
comes back empty. The branch-rewrite sites only issue ISB; DSB ISH,
which performs no D-cache clean or I-cache invalidation and is ordered
backwards for self-modifying code besides. On ARMv8 a correct
publication needs the DC CVAU / IC IVAU broadcast sequence; x86 has a
coherent instruction cache, so none of this was ever visible there.
All sites use the bundled asmjit::VirtMem::flushInstructionCache(),
which emits that sequence portably across toolchains.

This covers every publication path I could find:

- MemoryManager1::finalizeMemory() and MemoryManager2::finalizeMemory()
  were both no-ops. RuntimeDyld calls finalizeMemory() after writing
  code and relies on it for cache maintenance, so LLVM emitted PPU and
  SPU code was never flushed. MemoryManager1 serves the primary PPU
  JIT, MemoryManager2 the SPU JIT and auxiliary engines. Both managers
  now record code section allocations and flush them on finalize. I
  confirmed at runtime that the MemoryManager2 path executes (about
  12800 calls per cold boot).
- jit_runtime_base::_add() copies asmjit output into executable memory
  with no flush.
- jit_runtime::finalize() restores an executable code snapshot in place
  during emulator restart with only the ISB/DSB pair.
- spu_runtime::rebuild_ubertrampoline() publishes a hand-written
  trampoline via CAS with no flush; the flush now happens before the
  publication.
- spu_runtime::make_branch_patchpoint() writes a patchpoint byte by
  byte and returns it with only the ISB/DSB pair.
- Both 16-byte branch-site rewrites (dispatch and branch) atomically
  overwrite live code and only issued the ISB/DSB pair.

The ISB/DSB pairs adjacent to the new flushes are removed along with
their misleading "flush all cache lines" comments: the flush helper
already issues the trailing barriers, and the pairs never performed
any cache maintenance in the first place.

I want to be upfront that this was not the cause of the hang I was
debugging (a same-item compilation race, fixed separately), and I have
not observed a failure that this change alone fixes. It is a latent
correctness issue on any ARM64 host: nothing prevents another core
from fetching stale instruction bytes for freshly published code.


**Validation:** I instrumented `MemoryManager2::finalizeMemory()` on ARM64 and observed approximately 12,800 calls covering 12.7 MB of generated code during a cold boot. The ARM64 core builds successfully with these changes. This patch has no known user-visible reproducer; the unrelated VT4 hang that led to its discovery is fixed separately in #18.
