### PR TITLE
Fix PS3 patch state reporting and verify downloaded patches

### DIFF
--- a/android/armsx3-ui/app/src/main/cpp/native-lib.cpp
+++ b/android/armsx3-ui/app/src/main/cpp/native-lib.cpp
@@ -60,6 +60,7 @@ struct RPCSXApi {
   bool (*saveStateToSlot)(unsigned int slot);
   bool (*loadStateFromSlot)(unsigned int slot);
   bool (*hasStateInSlot)(unsigned int slot);
+  std::string (*patchEngineVersion)();
   int (*patchesImport)(std::string_view content);
   std::string (*patchesList)(std::string_view serial);
   std::string (*probeDiscInfo)(std::string_view isoPath, std::string_view iconOut);
@@ -139,6 +140,7 @@ struct RPCSXLibrary : RPCSXApi {
     result.saveStateToSlot = reinterpret_cast<decltype(saveStateToSlot)>(dlsym(handle, "_rpcsx_saveStateToSlot"));
     result.loadStateFromSlot = reinterpret_cast<decltype(loadStateFromSlot)>(dlsym(handle, "_rpcsx_loadStateFromSlot"));
     result.hasStateInSlot = reinterpret_cast<decltype(hasStateInSlot)>(dlsym(handle, "_rpcsx_hasStateInSlot"));
+    result.patchEngineVersion = reinterpret_cast<decltype(patchEngineVersion)>(dlsym(handle, "_rpcsx_patchEngineVersion"));
     result.patchesImport = reinterpret_cast<decltype(patchesImport)>(dlsym(handle, "_rpcsx_patchesImport"));
     result.patchesList = reinterpret_cast<decltype(patchesList)>(dlsym(handle, "_rpcsx_patchesList"));
     result.probeDiscInfo = reinterpret_cast<decltype(probeDiscInfo)>(dlsym(handle, "_rpcsx_probeDiscInfo"));
@@ -654,6 +656,17 @@ Java_net_rpcsx_RPCSX_hasStateInSlot(JNIEnv *, jobject, jint slot) {
 // ---------------------------------------------------------------------------
 // Patches
 // ---------------------------------------------------------------------------
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_net_rpcsx_RPCSX_patchEngineVersion(JNIEnv *env, jobject) {
+  // Empty rather than a guessed version: the caller asks precisely because it
+  // must not name a schema version of its own.
+  if (rpcsxLib.patchEngineVersion == nullptr) {
+    return wrap(env, "");
+  }
+
+  return wrap(env, rpcsxLib.patchEngineVersion());
+}
 
 extern "C" JNIEXPORT jint JNICALL
 Java_net_rpcsx_RPCSX_patchesImport(JNIEnv *env, jobject, jstring jcontent) {

--- a/android/armsx3-ui/app/src/main/java/com/armsx2/Ps3PatchRepo.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/Ps3PatchRepo.kt
@@ -22,8 +22,14 @@ object Ps3PatchRepo {
      * RPCS3's official patch feed. `v` is the patch-engine version the server
      * uses to decide which schema to hand back, so it is not cosmetic -- an
      * older value returns patches this core cannot parse.
+     *
+     * The version comes from the core (patch_engine_version) rather than being
+     * written here. It was spelled out as 1.2, which is correct only until
+     * upstream bumps the constant: patch_engine::load rejects any file whose
+     * Version header does not match, so the two have to move together.
      */
-    private const val PATCH_URL = "https://rpcs3.net/compatibility?patch&api=v1&v=1.2"
+    private fun patchUrl(version: String) =
+        "https://rpcs3.net/compatibility?patch&api=v1&v=$version"
 
     data class Patch(
         val hash: String,
@@ -49,11 +55,15 @@ object Ps3PatchRepo {
         data object Network : Result
         data class Server(val code: Int) : Result
         data object Parse : Result
+        data object Checksum : Result
     }
 
     fun download(): Result {
+        val engineVersion = runCatching { RPCSX.instance.patchEngineVersion() }.getOrDefault("")
+        if (engineVersion.isBlank()) return Result.Parse
+
         val res = runCatching {
-            com.armsx3.HttpClient.doRequest(PATCH_URL, userAgent = "ARMSX3")
+            com.armsx3.HttpClient.doRequest(patchUrl(engineVersion), userAgent = "ARMSX3")
         }.getOrNull() ?: return Result.Network
 
         if (res.statusCode != 200 || res.data.isEmpty()) return Result.Network
@@ -62,18 +72,39 @@ object Ps3PatchRepo {
         //   { "return_code": 0, "version": "1.2", "sha256": "...", "patch": "<yaml>" }
         // Handing the envelope straight to the YAML parser fails on the first
         // line, which is exactly what it did.
-        val yaml = runCatching {
+        val envelope = runCatching {
             val obj = org.json.JSONObject(String(res.data, Charsets.UTF_8))
             val code = obj.optInt("return_code", -1)
             if (code != 0) return Result.Server(code)
-            obj.optString("patch")
-        }.getOrNull()
+            obj
+        }.getOrNull() ?: return Result.Parse
 
-        if (yaml.isNullOrBlank()) return Result.Parse
+        // The server picks the schema from the version we asked for, so a reply
+        // for a different one is a server-side surprise rather than something to
+        // hand to the parser: patch_engine::load would reject the whole file on
+        // its Version header anyway, several megabytes later.
+        if (envelope.optString("version") != engineVersion) return Result.Parse
+
+        val yaml = envelope.optString("patch")
+        if (yaml.isBlank()) return Result.Parse
+
+        // Desktop RPCS3 verifies this digest before it writes anything
+        // (patch_manager_dialog::handle_json), and the check was missing here.
+        // Patches are writes into the guest executable, and move_file/hide_file
+        // patches reach the emulator's own filesystem, so content that is not
+        // what the server hashed does not get imported.
+        val expected = envelope.optString("sha256")
+        if (!expected.equals(sha256(yaml), ignoreCase = true)) return Result.Checksum
 
         val n = runCatching { RPCSX.instance.patchesImport(yaml) }.getOrDefault(-1)
         return if (n >= 0) Result.Ok(n) else Result.Parse
     }
+
+    /** Lowercase hex SHA-256, the form rpcs3.net sends and desktop compares against. */
+    private fun sha256(text: String): String =
+        java.security.MessageDigest.getInstance("SHA-256")
+            .digest(text.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
 
     /**
      * Patches applicable to a serial. An empty serial lists everything, which is

--- a/android/armsx3-ui/app/src/main/java/com/armsx2/i18n/I18n.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/i18n/I18n.kt
@@ -600,6 +600,7 @@ val EN: Map<String, String> = mapOf(
     "patches.ps3.serverError" to "RPCS3's patch server returned an error.",
     "patches.ps3.parseFailed" to "The patch database downloaded but could not be read. It may be for a newer patch format than this build supports.",
     "patches.ps3.toggleFailed" to "Could not change that patch.",
+    "patches.ps3.restartNeeded" to "Patches are applied while the game loads. A change here takes effect the next time you launch it, not in a game that is already running.",
     "patches.ps3.emptyAll" to "No patches yet. Download the database above to get started.",
     "patches.ps3.emptyGame" to "No patches available for this game. Try downloading the database above.",
     "common.off" to "Off",

--- a/android/armsx3-ui/app/src/main/java/com/armsx2/i18n/I18n.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/i18n/I18n.kt
@@ -600,6 +600,7 @@ val EN: Map<String, String> = mapOf(
     "patches.ps3.serverError" to "RPCS3's patch server returned an error.",
     "patches.ps3.parseFailed" to "The patch database downloaded but could not be read. It may be for a newer patch format than this build supports.",
     "patches.ps3.toggleFailed" to "Could not change that patch.",
+    "patches.ps3.checksumFailed" to "The patch database did not match its checksum, so nothing was imported. Try again.",
     "patches.ps3.restartNeeded" to "Patches are applied while the game loads. A change here takes effect the next time you launch it, not in a game that is already running.",
     "patches.ps3.emptyAll" to "No patches yet. Download the database above to get started.",
     "patches.ps3.emptyGame" to "No patches available for this game. Try downloading the database above.",

--- a/android/armsx3-ui/app/src/main/java/com/armsx2/ui/patches/Ps3PatchesTab.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/ui/patches/Ps3PatchesTab.kt
@@ -176,6 +176,17 @@ fun Ps3PatchesTab(serial: String = "") {
             return@Column
         }
 
+        // The core builds its patch map once, while the game loads, and writes
+        // the patches into the executable as each module is loaded. Toggling
+        // here only rewrites patch_config.yml, so a running game is unaffected
+        // and the toggle looks broken without saying this.
+        Text(
+            str("patches.ps3.restartNeeded"),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 10.dp),
+        )
+
         @Composable
         fun patchRow(patch: Ps3PatchRepo.Patch) {
             ToggleRow(

--- a/android/armsx3-ui/app/src/main/java/com/armsx2/ui/patches/Ps3PatchesTab.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/ui/patches/Ps3PatchesTab.kt
@@ -108,6 +108,7 @@ fun Ps3PatchesTab(serial: String = "") {
                         is Ps3PatchRepo.Result.Server ->
                             str2("patches.ps3.serverError") + " (${r.code})"
                         Ps3PatchRepo.Result.Parse -> str2("patches.ps3.parseFailed")
+                        Ps3PatchRepo.Result.Checksum -> str2("patches.ps3.checksumFailed")
                     }
                 }
             },

--- a/android/armsx3-ui/app/src/main/java/net/rpcsx/RPCSX.kt
+++ b/android/armsx3-ui/app/src/main/java/net/rpcsx/RPCSX.kt
@@ -119,6 +119,7 @@ class RPCSX {
     external fun saveStateToSlot(slot: Int): Boolean
     external fun loadStateFromSlot(slot: Int): Boolean
     external fun hasStateInSlot(slot: Int): Boolean
+    external fun patchEngineVersion(): String
     external fun patchesImport(content: String): Int
     external fun patchesList(serial: String): String
     external fun probeDiscInfo(isoPath: String, iconOut: String): String

--- a/android/src/rpcsx-android.cpp
+++ b/android/src/rpcsx-android.cpp
@@ -2685,6 +2685,19 @@ static std::string json_quote(std::string_view v) {
   return out + "\"";
 }
 
+/**
+ * The patch schema version this core can parse.
+ *
+ * rpcs3.net serves a different schema per version and patch_engine::load
+ * rejects a file whose Version header does not match, so the app has to ask
+ * for the version built into the core rather than name one itself. It had 1.2
+ * hardcoded in the download URL, which is right until upstream bumps the
+ * constant and every download starts failing to parse.
+ */
+extern "C" std::string _rpcsx_patchEngineVersion() {
+  return patch_engine_version;
+}
+
 extern "C" int _rpcsx_patchesImport(std::string_view content) {
   patch_engine::patch_map patches;
   std::stringstream log;
@@ -2841,17 +2854,24 @@ extern "C" std::string _rpcsx_patchesList(std::string_view serial) {
 
   for (const auto &[hash, container] : db) {
     for (const auto &[description, info] : container.patch_info_map) {
-      // A patch lists the titles it applies to; keep only ones naming this
-      // serial, or the "all games" wildcard RPCS3 uses.
-      // titles maps GAME TITLE -> serial -> app_version. "all" is RPCS3's
-      // wildcard serial, used by patches that are not tied to one release.
+      // A patch lists the titles it applies to; a per-game list keeps only the
+      // ones naming this serial.
+      //
+      // Deliberately NOT patch_key::all here. Wildcard patches are keyed by SPU
+      // or PPU hash and leave the serial as "All" because the hash is the
+      // filter, so they belong to no particular game: the database has 17 of
+      // them and listing them under every game buries each game's own handful,
+      // while toggling one from a game's list writes the shared "All" entry and
+      // changes every other game too. Desktop RPCS3 shows them once, under
+      // their own "All titles" node (patch_manager_dialog.cpp), and the global
+      // list below (empty serial) is this app's equivalent.
       bool applies = serial.empty();
       std::string app_version = "all";
       std::string game_title;
 
       for (const auto &[title, serials] : info.titles) {
         for (const auto &[ser, versions] : serials) {
-          const bool hit = (!serial.empty() && ser == serial) || ser == "all";
+          const bool hit = !serial.empty() && ser == serial;
           if (hit || serial.empty()) {
             if (game_title.empty()) game_title = title;
           }
@@ -2870,14 +2890,17 @@ extern "C" std::string _rpcsx_patchesList(std::string_view serial) {
       // an enabled entry under that game's serial and none under this one --
       // counting any enabled entry reported it as on for every game the patch
       // covers, and the row then showed a toggle the game was not getting.
-      // "all" is RPCS3's wildcard serial and does apply here, so it counts.
+      // A wildcard entry still counts: a patch listed here for its own serial
+      // can also carry an "All" entry, and an enabled one of those does reach
+      // this game even though wildcard-only patches are not listed above.
       bool is_on = false;
       if (auto it = enabled.find(hash); it != enabled.end()) {
         if (auto p = it->second.patch_info_map.find(description);
             p != it->second.patch_info_map.end()) {
           for (const auto &[title, serials] : p->second.titles)
             for (const auto &[ser, versions] : serials) {
-              if (!serial.empty() && ser != serial && ser != "all") continue;
+              if (!serial.empty() && ser != serial && ser != patch_key::all)
+                continue;
               for (const auto &[ver, values] : versions)
                 if (values.enabled) is_on = true;
             }
@@ -2934,10 +2957,13 @@ extern "C" bool _rpcsx_patchSetEnabled(std::string_view hash,
   auto &info = entry.patch_info_map[std::string(description)];
   info = p->second;
 
+  // patch_key::all is spelled "All"; the lowercase literal this used to compare
+  // against never matched, so a wildcard patch toggled from a game's own list
+  // wrote nothing and the switch did nothing.
   for (auto &[title, serials] : info.titles)
     for (auto &[ser, versions] : serials)
       for (auto &[ver, values] : versions)
-        if (ser == serial || serial.empty() || ser == "all")
+        if (ser == serial || serial.empty() || ser == patch_key::all)
           values.enabled = enabled;
 
   patch_engine::save_config(config);

--- a/android/src/rpcsx-android.cpp
+++ b/android/src/rpcsx-android.cpp
@@ -2865,14 +2865,22 @@ extern "C" std::string _rpcsx_patchesList(std::string_view serial) {
 
       if (!applies) continue;
 
+      // Enabled state has to be read for THIS serial only. patchSetEnabled
+      // writes per serial, so a patch switched on from another game's list has
+      // an enabled entry under that game's serial and none under this one --
+      // counting any enabled entry reported it as on for every game the patch
+      // covers, and the row then showed a toggle the game was not getting.
+      // "all" is RPCS3's wildcard serial and does apply here, so it counts.
       bool is_on = false;
       if (auto it = enabled.find(hash); it != enabled.end()) {
         if (auto p = it->second.patch_info_map.find(description);
             p != it->second.patch_info_map.end()) {
           for (const auto &[title, serials] : p->second.titles)
-            for (const auto &[ser, versions] : serials)
+            for (const auto &[ser, versions] : serials) {
+              if (!serial.empty() && ser != serial && ser != "all") continue;
               for (const auto &[ver, values] : versions)
                 if (values.enabled) is_on = true;
+            }
         }
       }
 


### PR DESCRIPTION
## What this fixes

Four things in the PS3 patch section.

**The patch list reported state that wasn't the game's.** `patchesList` marked a patch as enabled if any entry under its hash was enabled, no matter which serial that entry belonged to. `patchSetEnabled` writes per serial, so a patch I switched on from one game showed as on in every other game that patch covers. The enabled scan now looks only at the requested serial, plus RPCS3's "All" wildcard, which really does reach the game being listed.

**Toggling a patch mid-game looked broken.** The engine builds its patch map once while the game loads and writes the patches into each module as it loads, so toggling only rewrites `patch_config.yml` and nothing happens in a running game. The in-game tab never said so. It does now.

**The download URL hardcoded the patch schema version as 1.2.** That is correct today, but `patch_engine::load` rejects any file whose Version header doesn't match `patch_engine_version`, so the day upstream bumps that constant every download starts failing to parse. The core now exposes the version through a new `patchEngineVersion()` and the URL is built from it. I also check the version the server echoes back, so a mismatch fails early instead of after several megabytes.

**Nothing verified the sha256 the server sends with the patch text.**
Desktop checks it before writing anything (`patch_manager_dialog::handle_json`). Patches are writes into the guest executable and `move_file`/`hide_file` patches reach the emulator's own filesystem, so content that isn't what the server hashed no longer gets imported. Mismatches get their own message instead of being reported as a parse failure.

There is also a spelling fix in `patchSetEnabled`: `patch_key::all` is `"All"`, and it compared against a lowercase `"all"`, so a patch carrying a wildcard entry never had that entry written. Nothing reaches that path today, since per-game lists only offer patches naming the serial, but it was a trap for whoever did.

Per-game lists stay serial-only on purpose. Wildcard patches are keyed by SPU or PPU hash and leave the serial as "All" because the hash is the filter, so they belong to no single game. Desktop shows them once under an "All titles" node; the global list here is the equivalent.

## Testing

Built and installed on an AYN Odin 3 (arm64, Android 15).

- Downloaded the database: 2001 patches imported. That exercises the version-from-core URL, the echoed version check and the sha256 compare in one go, since any of them failing blocks the import.
- Skate 3 (BLUS30464) lists its own four patches and nothing else.
- Virtua Tennis 4 (BLUS30529), which has no patches in the database, correctly says so.
- Enabled a patch, confirmed the entry written to `patch_config.yml`, toggled it off, confirmed the entry removed.
- The restart notice renders in both the global Settings tab and the in-game one.