### PR TITLE
RSX: vectorize the primitive-restart index upload on ARM64

### DIFF
--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -426,6 +426,10 @@ namespace
 
 			if (count >= 8)
 			{
+				// ORR with the compare mask writes all-ones into restart lanes; that only
+				// matches the tail's index_limit store while index_limit is all bits set.
+				static_assert(index_limit<u16>() == 0xffff);
+
 				const uint16x8_t vrestart = vdupq_n_u16(restart_index);
 				uint16x8_t vmin = vdupq_n_u16(0xffff);
 				uint16x8_t vmax = vdupq_n_u16(0);
@@ -463,6 +467,9 @@ namespace
 
 			if (count >= 4)
 			{
+				// Same all-ones requirement as the u16 overload above.
+				static_assert(index_limit<u32>() == 0xffffffffu);
+
 				const uint32x4_t vrestart = vdupq_n_u32(restart_index);
 				uint32x4_t vmin = vdupq_n_u32(0xffffffffu);
 				uint32x4_t vmax = vdupq_n_u32(0);

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -253,6 +253,7 @@ DECLARE(copy_data_swap_u32) = copy_data_swap_u32_naive<false>;
 DECLARE(copy_data_swap_u32_cmp) = copy_data_swap_u32_naive<true>;
 #endif
 
+
 namespace
 {
 	template <typename T>
@@ -392,6 +393,102 @@ namespace
 			return (u64{max_index} << 32) | u64{min_index};
 		}
 
+#if defined(ARCH_ARM64)
+		// Eight u16 (four u32) per iteration instead of one.
+		//
+		// The SIMD build of this loop is assembled by asmjit under ARCH_X64 only, so ARM64
+		// fell through to the scalar loop above -- and unlike the non-restart loop, clang
+		// cannot auto-vectorize this one ("value that could not be identified as reduction
+		// is used outside the loop"): the min/max updates are themselves conditional on the
+		// restart compare. Measured on a Snapdragon 8 Elite, Virtua Tennis 4 routes its
+		// entire indexed-draw traffic through here -- a median of ~159k indices per frame
+		// in a match -- at 16 scalar instructions per index.
+		//
+		// Same lane algebra as the x86 asmjit builder below: the restart-equal mask ORs
+		// the lane to all-ones for the min accumulator and the store (all-ones is
+		// index_limit, exactly what the scalar loop writes), and BICs it to zero for the
+		// max accumulator, so restart lanes can never win either reduction. Horizontal
+		// UMINV/UMAXV once at the end. Tail stays scalar.
+		//
+		// CONTRACT: src and dst must not overlap. The vector body reads a full lane
+		// group before writing it back, so a partial overlap diverges from the scalar
+		// loop's element-wise order. Both callers (VK/GL vertex upload) hand a guest
+		// memory span as src and a freshly mapped ring-buffer span as dst.
+		static inline u64 upload_untouched_neon(const be_t<u16>* src, u16* dst, u32 count, u16 restart_index)
+		{
+			u32 i = 0;
+			u16 min_index = index_limit<u16>();
+			u16 max_index = 0;
+
+			if (count >= 8)
+			{
+				const uint16x8_t vrestart = vdupq_n_u16(restart_index);
+				uint16x8_t vmin = vdupq_n_u16(0xffff);
+				uint16x8_t vmax = vdupq_n_u16(0);
+
+				for (; i + 8 <= count; i += 8)
+				{
+					const uint16x8_t v = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(
+						vld1q_u16(reinterpret_cast<const u16*>(src) + i))));
+					const uint16x8_t eq = vceqq_u16(v, vrestart);
+					const uint16x8_t v_or_ones = vorrq_u16(v, eq);
+
+					vmin = vminq_u16(vmin, v_or_ones);
+					vmax = vmaxq_u16(vmax, vbicq_u16(v, eq));
+					vst1q_u16(dst + i, v_or_ones);
+				}
+
+				min_index = vminvq_u16(vmin);
+				max_index = vmaxvq_u16(vmax);
+			}
+
+			for (; i < count; ++i)
+			{
+				const u16 index = src[i].value();
+				dst[i] = index == restart_index ? index_limit<u16>() : min_max(min_index, max_index, index);
+			}
+
+			return (u64{max_index} << 32) | u64{min_index};
+		}
+
+		static inline u64 upload_untouched_neon(const be_t<u32>* src, u32* dst, u32 count, u32 restart_index)
+		{
+			u32 i = 0;
+			u32 min_index = index_limit<u32>();
+			u32 max_index = 0;
+
+			if (count >= 4)
+			{
+				const uint32x4_t vrestart = vdupq_n_u32(restart_index);
+				uint32x4_t vmin = vdupq_n_u32(0xffffffffu);
+				uint32x4_t vmax = vdupq_n_u32(0);
+
+				for (; i + 4 <= count; i += 4)
+				{
+					const uint32x4_t v = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(
+						vld1q_u32(reinterpret_cast<const u32*>(src) + i))));
+					const uint32x4_t eq = vceqq_u32(v, vrestart);
+					const uint32x4_t v_or_ones = vorrq_u32(v, eq);
+
+					vmin = vminq_u32(vmin, v_or_ones);
+					vmax = vmaxq_u32(vmax, vbicq_u32(v, eq));
+					vst1q_u32(dst + i, v_or_ones);
+				}
+
+				min_index = vminvq_u32(vmin);
+				max_index = vmaxvq_u32(vmax);
+			}
+
+			for (; i < count; ++i)
+			{
+				const u32 index = src[i].value();
+				dst[i] = index == restart_index ? index_limit<u32>() : min_max(min_index, max_index, index);
+			}
+
+			return (u64{max_index} << 32) | u64{min_index};
+		}
+#endif
+
 #ifdef ARCH_X64
 		template <typename T>
 		static void build_upload_untouched(asmjit::simd_builder& c, native_args& args)
@@ -470,6 +567,8 @@ namespace
 				r = upload_xi16(src.data(), dst.data(), count, restart_index);
 			else
 				r = upload_xi32(src.data(), dst.data(), count, restart_index);
+#elif defined(ARCH_ARM64)
+			r = upload_untouched_neon(src.data(), dst.data(), count, restart_index);
 #else
 			r = upload_untouched_naive(src.data(), dst.data(), count, restart_index);
 #endif
@@ -884,3 +983,4 @@ std::tuple<u32, u32, u32> write_index_array_data_to_buffer(std::span<std::byte> 
 		fmt::throw_exception("Unreachable");
 	}
 }
+

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -253,7 +253,6 @@ DECLARE(copy_data_swap_u32) = copy_data_swap_u32_naive<false>;
 DECLARE(copy_data_swap_u32_cmp) = copy_data_swap_u32_naive<true>;
 #endif
 
-
 namespace
 {
 	template <typename T>
@@ -366,6 +365,9 @@ namespace
 			else
 				r = upload_xi32(src.data(), dst.data(), count);
 #else
+			// No hand-written ARM64 path here on purpose: this loop has no conditional
+			// min/max, so clang auto-vectorizes it (unlike the restart variant below,
+			// which needs the explicit NEON port).
 			r = upload_untouched_naive(src.data(), dst.data(), count);
 #endif
 
@@ -412,8 +414,10 @@ namespace
 		//
 		// CONTRACT: src and dst must not overlap. The vector body reads a full lane
 		// group before writing it back, so a partial overlap diverges from the scalar
-		// loop's element-wise order. Both callers (VK/GL vertex upload) hand a guest
-		// memory span as src and a freshly mapped ring-buffer span as dst.
+		// loop's element-wise order. Both callers (VK/GL vertex upload) pass disjoint
+		// allocations: src is guest memory (or the immediate-mode push buffer), dst a
+		// freshly mapped ring-buffer span (or, when the driver quirk forces restart
+		// emulation, a fresh heap staging block).
 		static inline u64 upload_untouched_neon(const be_t<u16>* src, u16* dst, u32 count, u16 restart_index)
 		{
 			u32 i = 0;
@@ -983,4 +987,3 @@ std::tuple<u32, u32, u32> write_index_array_data_to_buffer(std::span<std::byte> 
 		fmt::throw_exception("Unreachable");
 	}
 }
-


### PR DESCRIPTION
## What it does

The primitive-restart index upload loop (`primitive_restart_impl::upload_untouched`) was scalar on ARM64 while x86-64 ships a SIMD version built by asmjit. Clang cannot auto-vectorize this loop (the min/max reductions are conditional on the restart compare — `-Rpass-analysis=loop-vectorize`: "value that could not be identified as reduction is used outside the loop"), so ARM64 paid ~16 instructions per index on the RSX thread.

This adds hand-written NEON ports of the u16 and u32 restart paths, mirroring the x86 lane algebra (`CMEQ` → `ORR`/`UMIN` for the min accumulator and store, `CMEQ` → `BIC`/`UMAX` for the max accumulator, horizontal `UMINV`/`UMAXV` once at the end, scalar tail). Dispatch is unconditional under `ARCH_ARM64`: every intrinsic used is mandatory ARMv8-A Advanced SIMD, verified by compiling the routines with NDK clang at `--target=aarch64-linux-android21 -march=armv8-a` and inspecting the emitted mnemonics — no runtime feature check, valid on every device the arm64-v8a build targets.

A `static_assert` beside each splat pins the identity the lane algebra relies on (`index_limit<T>()` == all-ones): if that ever changes, the ARM64 build fails instead of the vector body silently diverging from its own scalar tail.

## Why it matters (measured)

Instrumented runs on an AYN Odin 3 (Snapdragon 8 Elite, Qualcomm driver 512.800.72), with cumulative per-path dispatch counters dumped every 120 flips:

- **Exposure**: restart usage is title-dependent and bimodal. Skate 3 and Mirror's Edge route 100% of their index traffic through the already-vectorized non-restart path (P3 = 0 across 30k/13k flips). **Virtua Tennis 4 routes every indexed draw through this scalar restart path**: 2.81 billion input indices in a 9.1-minute match, median ~159k indices per flip (max single flip 306k), ~100% u16, ~99.9% of indices in vectorizable-size calls (n ≥ 8). At 16 instructions/index that is ~2.5M instructions per flip on the RSX thread.
- **A/B on device** (scalar vs NEON builds, identical otherwise, same driven VT4 match, run order A,B,B,A for thermal symmetry, fresh process per run):

  | run | build | median net ticks/index | ns/index |
  |---|---|---|---|
  | 1 | A scalar | 0.02504 | 1.304 |
  | 2 | B NEON   | 0.00346 | 0.180 |
  | 3 | B NEON   | 0.00381 | 0.198 |
  | 4 | A scalar | 0.02464 | 1.284 |

  Ratio B/A = **0.146** (~6.9× faster) on the primary metric; A–A spread 1.6%, B–B spread 9.6%, distributions non-overlapping. Worst single flip in this loop: 3.64 ms scalar → 0.99 ms NEON. At the median match load the loop costs ~207 µs/frame scalar vs ~30 µs NEON. FPS stayed 60/60 in all four runs on this device (it has headroom); the payoff is RSX-thread occupancy and worst-frame cost, not average fps here.
- **Correctness**: a 216-case differential (naive vs NEON kernel vs the dispatched path; all tail residues, restart edge values, limit-present-but-not-restart, u16 and u32) ran **on device** in all four A/B runs with 0 mismatches. A host-side differential over 164k randomized cases (independently transcribed lane semantics vs the scalar reference) also reports 0 mismatches.

Caveats: single device / single driver — the 6.9× ratio is not established on other SoCs or on Turnip. The u32 overload is covered by the differentials but no title in this corpus exercises it. The instrumentation used for these numbers was removed before this branch; only the port (+ comments + the static_asserts) ships.

## Notes

- The non-restart loop is left alone on ARM64: clang already auto-vectorizes it (VF=8), confirmed in the shipped object file; a comment at the dispatch now says the asymmetry is deliberate.
- `src`/`dst` no-overlap contract is stated at the functions; both callers (VK/GL) pass disjoint allocations.
- The change is +110 lines in `rpcs3/Emu/RSX/Common/BufferUtils.cpp`, nothing else.
