### PR TITLE
UI: Lingering Playstation 2 naming on the side menu during execution

### DIFF
--- a/android/armsx3-ui/app/src/main/java/com/armsx2/ui/emulation/EmulationMenuScreen.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/ui/emulation/EmulationMenuScreen.kt
@@ -539,7 +539,7 @@ private fun MenuHeader(
         Column(Modifier.weight(1f)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    game?.title ?: "PlayStation 2",
+                    game?.title ?: "PlayStation 3",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     maxLines = 1,


### PR DESCRIPTION
Lingering Playstation 2 naming on the side menu during execution