### PR TITLE
Android CPU time: park the dma_manager::sync() wait, and stop re-parsing the global config every 5s

### DIFF
--- a/android/armsx3-ui/app/src/main/java/com/armsx2/config/ConfigStore.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/config/ConfigStore.kt
@@ -109,7 +109,20 @@ object ConfigStore {
     private const val BACKUP_FILENAME = "armsx2-settings.json"
     private fun keyForGame(serial: String) = "config.game.$serial"
 
+    // Memoized result of loadGlobal(). The function below is a JSON parse plus every
+    // migration block in this file -- 24,555 dex instructions by ART's count, over its
+    // JIT ceiling, so it runs interpreted every single call. That would be fine if it
+    // were called rarely, but EmulationSurface's frame-rate monitor re-resolves the
+    // config every 5 seconds of gameplay (measured: one ART bailout log line per 5.00s
+    // for entire sessions), all to read one boolean. The migrations are one-shot by
+    // their own prefs flags, so caching the parsed result is behavior-identical; the
+    // cache is refreshed by saveGlobal (the only writer of KEY_GLOBAL after boot) and
+    // dropped by reconcileReusedFolder, whose restore writes the pref directly.
+    @Volatile
+    private var cachedGlobal: Settings? = null
+
     fun loadGlobal(): Settings {
+        cachedGlobal?.let { return it }
         val raw = MainActivityRuntime.prefs.getString(KEY_GLOBAL, null)
         var parsed = if (raw != null) {
             try { Settings.fromJson(JSONObject(raw)) } catch (_: Exception) { Settings() }
@@ -567,6 +580,7 @@ object ConfigStore {
         }
 
         if (dirty) saveGlobal(parsed)
+        cachedGlobal = parsed
         return parsed
     }
 
@@ -586,6 +600,7 @@ object ConfigStore {
 
     fun saveGlobal(s: Settings) {
         MainActivityRuntime.prefs.edit { putString(KEY_GLOBAL, s.toJson().toString()) }
+        cachedGlobal = s
         writeBackupMirror()
     }
 
@@ -769,6 +784,10 @@ object ConfigStore {
         MainActivityRuntime.prefs.edit { putBoolean(KEY_FOLDER_RECONCILE, true) }
         // Hard guard: an existing new-UI user (has config.global) is off-limits.
         if (MainActivityRuntime.prefs.getString(KEY_GLOBAL, null) != null) return
+
+        // The restore below writes KEY_GLOBAL behind loadGlobal's back; drop any
+        // default Settings() a pre-restore call may have pinned in the cache.
+        cachedGlobal = null
 
         // (1) Lossless restore from the in-folder mirror (written by a prior new-UI install).
         val mirror = backupFile()

--- a/rpcs3/Emu/RSX/RSXOffload.cpp
+++ b/rpcs3/Emu/RSX/RSXOffload.cpp
@@ -197,10 +197,65 @@ namespace rsx
 				return false;
 			}
 
-			while (_thr.m_enqueued_count.load() > _thr.m_processed_count.load())
+			// Spin briefly for the short common handoff, then park until the offloader
+			// drains the queue (it notify_all()s m_processed_count then -- see operator()
+			// above) or 100us pass, whichever is first. Before this, the loop was a pure
+			// pause() spin: measured on MGR gameplay (Odin, warm shader cache), it held
+			// 26.6% of the RSX thread's wall time while the offloader sat parked at 99.8%,
+			// burning a core per wake latency on every small handoff.
+			//
+			// The timeout is load-bearing, not a formality. Two conditions leave the
+			// drain-notify unable to fire while work is outstanding: the offloader can be
+			// stopped mid-job by a memory fault (it then spins in on_access_violation
+			// until THIS thread's upkeep clears the deadlock flag), and the upkeep below
+			// can itself enqueue new jobs from inside the wait (queue_submit callbacks
+			// reach backend_ctrl through flush_command_queue), which pushes the
+			// equal-counters notify out to the next drain. Both resolve within one
+			// timeout tick, and neither may ever be used to justify removing it.
+			//
+			// on_semaphore_acquire_wait() runs on every iteration because it is the only
+			// agent that clears an offloader fault-deadlock, and, on paths that have not
+			// set the 'flushing' guard, it services pending flushes and async flips.
+			//
+			// Park only when the upkeep call made no progress visible: the drain-notify
+			// is one-shot, so parking on a value read before the upkeep would absorb a
+			// whole timeout when the offloader drained during it -- and parking on a
+			// blind re-read makes any PARTIAL progress during the upkeep return the
+			// wait immediately, degrading the park into a hot upkeep loop for the whole
+			// drain. If the count moved, loop and re-evaluate; if it did not, the
+			// pre-upkeep value is still current and is the correct wait target.
+			//
+			// If the offloader thread is not running -- never started because the config
+			// was off at boot and toggled on mid-session, aborting, or dead from an
+			// unrecoverable fault -- the drain can never come. Do not park then: keep the
+			// visible spin, so the (pre-existing) hang shows up as a busy RSX thread in
+			// any profiler instead of an idle one that reads as a healthy app.
+			u32 spins = 0;
+
+			while (true)
 			{
+				const u64 processed = _thr.m_processed_count.load();
+
+				if (_thr.m_enqueued_count.load() <= processed)
+				{
+					break;
+				}
+
 				rsxthr->on_semaphore_acquire_wait();
-				utils::pause();
+
+				if (++spins < 500 || static_cast<thread_state>(_thr) != thread_state::created)
+				{
+					utils::pause();
+					continue;
+				}
+
+				if (_thr.m_processed_count.load() != processed)
+				{
+					// Progress during the upkeep call -- re-evaluate before parking.
+					continue;
+				}
+
+				_thr.m_processed_count.wait(processed, atomic_wait_timeout{100'000});
 			}
 		}
 		else


### PR DESCRIPTION
Two independent CPU-time fixes found while profiling Metal Gear Rising: Revengeance on an Odin (Snapdragon 8 Elite class, Adreno 830, a15 build). Neither changes frame rate; both remove work from threads that were burning it for nothing, which on a handheld is thermal budget.

All numbers below are from that one device and one title, warm shader cache, scene and input script held identical across A/B legs. Instruments: `simpleperf --trace-offcpu` for wall-time shares, `-e instructions` for instruction counts, the in-emulator overlay for fps — the overlay was calibrated against SurfaceFlinger present timestamps and agreed within ~1 fps in steady state.

## RSX: park the dma_manager::sync() wait instead of spinning

The RSX-thread branch of `dma_manager::sync()` busy-waited on the offloader with a bare `pause()` loop. Off-CPU profile during gameplay: that loop held **26.6% of the RSX thread's wall time** while the RSX Offloader thread itself was parked in a kernel wait for **99.78%** of the same window — the spin was paying the offloader's wake-up latency on every small handoff, burning roughly a quarter of a core to wait for a mostly-idle thread.

After the change: `sync()` falls to **0.10%** of RSX-thread wall time, the thread parks in the kernel for 67.6% of the same workload, and fps is unchanged (52.9 avg vs 51.4 for the pre-fix build in the same session). The defect reproduces on unmodified 0.8 at **27.35%**, so this is not something the release already fixed.

The 100us timeout is load-bearing rather than a formality. Two conditions leave the drain-notify unable to fire while work is still outstanding:

- an offloader stopped mid-job by a memory fault cannot reach its notify — it spins in `on_access_violation` until this thread's upkeep clears the deadlock flag;
- the upkeep call itself can enqueue new jobs from inside the wait (`flush_command_queue` reaches `backend_ctrl`), which pushes the equal-counters notify out to the next drain.

The first draft of this change carried a comment claiming nothing else could enqueue during the wait. That was false and would have licensed removing the timeout, so the committed comment states the real model.

Three refinements came out of an eight-lens blind review of the first version:

- The wait targets the processed count the loop condition observed, and parks only if a re-read after the upkeep call shows no progress. The drain-notify is one-shot: parking on a pre-upkeep value absorbs a full timeout when the offloader drained during upkeep, and parking on a blind re-read turns any partial progress into an immediate return, degrading the park into a hot upkeep loop for the whole drain. Both wrong variants were built and measured before this one.
- If the offloader thread is not running — config toggled on mid-session after booting with it off, aborting, or dead from an unrecoverable fault — the drain can never come. The loop keeps the visible spin in that case, so the pre-existing hang stays attributable in a profiler instead of presenting as an idle, healthy-looking app.
- `on_semaphore_acquire_wait()` still runs on every iteration; it is the only agent that clears an offloader fault-deadlock.

Known, deliberately not addressed here:

- On the offloader-fault path the deadlock flag now clears in <=100us quanta instead of at spin rate, so the burned core moves to the offloader for that duration. Exposure unmeasured — MGR did not exercise that path in any profiled window.
- Flush producers and emu-requested async flips can gain up to 100us of service latency while the RSX thread is parked. `RSXThread.cpp` notes the emu flip "has to be executed immediately"; the added bound is not measured against any tolerance.
- `m_processed_count` is `atomic_t<u64>`, so this binds the `[[deprecated]]` 8-byte `atomic_t::wait` overload (`util/atomic.hpp:1699`). `CPUThread.cpp:1098` uses the same overload on a hot path. A u32 sequence counter would avoid both.
- `GLGSRender::on_semaphore_acquire_wait` has no deadlock term and the base `rsx::thread::on_semaphore_acquire_wait` is an empty virtual, so the fault-recovery mechanism this loop leans on is Vulkan-only.
- The non-RSX-thread branch of `sync()` has the same spin shape; unmeasured and untouched.

## UI: stop re-parsing the whole global config every 5 seconds of gameplay

`ConfigStore.loadGlobal()` is a JSON parse plus every migration block in the file — **24,555 dex instructions by ART's own count**, over its JIT ceiling, so it runs interpreted on every call. `EmulationSurface`'s frame-rate monitor calls it through `resolveForGame()` every 5 seconds for the whole session, to read one boolean (`vsyncQueueSize == 0`).

Measured before: one ART "exceeds compiler instruction limit" bailout line per 5.00 s — 26 lines across a 125 s gameplay capture. After: one line for the entire session (the single first-call compile attempt), and the boot config dump still carries the user's settings.

The parsed `Settings` is memoized. The migrations are one-shot behind their own prefs flags, so caching is behavior-identical; `saveGlobal` is the only writer of the pref after boot and refreshes the cache, and `reconcileReusedFolder` — whose restore path writes the pref directly, before any settings screen exists — drops it.

## Not covered

- Single device, single title for both changes.
- No test exists for `dma_manager::sync()` and none is added; the evidence is the before/after profile plus the A/B against unmodified 0.8.
- Neither change moves frame rate, and neither was expected to. The win is a freed core and its thermal budget.
