### PR TITLE
SPU: make the ARM64 uncompilable-block fallback safe to enter

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -193,6 +193,7 @@ if(BUILD_RPCS3_TESTS)
             tests/test_rsx_fp_asm.cpp
             tests/test_dmux_pamf.cpp
             tests/test_spu_analyser.cpp
+            tests/test_spu_failed_blocks.cpp
             tests/test_types_util.cpp
     )
 

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -21,6 +21,7 @@
 
 #include "SPUThread.h"
 #include "SPUAnalyser.h"
+#include "SPUFailedBlocks.h"
 #include "SPUInterpreter.h"
 #include "SPUDisAsm.h"
 #include <algorithm>
@@ -124,35 +125,30 @@ static shared_mutex s_spu_failed_blocks_mutex;
 // one instruction, whereupon the recompiler tried the NEXT address, failed the same way, and
 // marked that too: 111 consecutive entries were recorded walking two blocks four bytes at a time,
 // each step paying a full failed LLVM compile.
-static std::map<u32, u32> s_spu_failed_blocks;
+//
+// Cleared per emulation session by the spu_runtime constructor. The keys are local-store offsets,
+// which every SPU thread, every image and every title in the process share, so a set that outlived
+// the session would let one title's compile failures route an unrelated title's code at the same
+// offset to the interpreter.
+static spu_failed_block_set s_spu_failed_blocks;
 
-static bool spu_interpreter_fallback_available()
+static void spu_reset_failed_blocks()
 {
-	const auto interp = spu_runtime::g_interpreter;
-	return interp && interp != spu_runtime::g_gateway;
+	std::lock_guard lock(s_spu_failed_blocks_mutex);
+	s_spu_failed_blocks.clear();
 }
 
-// Range containing addr, or {0,0}. Same lookup as spu_block_compile_failed, but returns the extent
-// so a caller can cache it and stop consulting this map.
-static std::pair<u32, u32> spu_block_failed_range(u32 addr)
+// The fallback is spu_recompiler_base::old_interpreter, which reads the opcode table, the thread
+// and the local store and nothing else -- see spu_thread::cpu_task. It is always linked, so on the
+// backends that can reach a failed block there is always something to fall back to.
+//
+// This previously tested spu_runtime::g_interpreter, which is the LLVM-built interpreter used when
+// the user selects a recompiler. That is a different object with a different failure mode: when it
+// fails to build, the check disabled a fallback that was in fact available, and dispatch dropped
+// into the "Compilation failed" path instead.
+static bool spu_interpreter_fallback_available()
 {
-	reader_lock lock(s_spu_failed_blocks_mutex);
-
-	auto it = s_spu_failed_blocks.upper_bound(addr);
-
-	if (it == s_spu_failed_blocks.begin())
-	{
-		return {};
-	}
-
-	--it;
-
-	if (addr >= it->first && addr < it->second)
-	{
-		return {it->first, it->second};
-	}
-
-	return {};
+	return true;
 }
 
 static bool spu_block_compile_failed(u32 addr)
@@ -161,15 +157,7 @@ static bool spu_block_compile_failed(u32 addr)
 
 	// Any recorded range containing addr, so execution stays interpreted for the whole of a block
 	// that cannot be compiled rather than only at its entry.
-	auto it = s_spu_failed_blocks.upper_bound(addr);
-
-	if (it == s_spu_failed_blocks.begin())
-	{
-		return false;
-	}
-
-	--it;
-	return addr >= it->first && addr < it->second;
+	return s_spu_failed_blocks.contains(addr);
 }
 
 static void spu_mark_block_compile_failed(u32 entry_point, u32 lower_bound = 0, u32 size_bytes = 0)
@@ -180,10 +168,93 @@ static void spu_mark_block_compile_failed(u32 entry_point, u32 lower_bound = 0, 
 	const u32 begin = size_bytes ? lower_bound : entry_point;
 	const u32 end = size_bytes ? lower_bound + size_bytes : entry_point + 4;
 
-	if (s_spu_failed_blocks.insert_or_assign(begin, std::max(end, s_spu_failed_blocks.count(begin) ? s_spu_failed_blocks[begin] : end)).second)
+	if (s_spu_failed_blocks.mark(begin, end))
 	{
 		spu_log.error("SPU block 0x%05x cannot be compiled on this backend, its thread switches to the interpreter", entry_point);
 	}
+}
+
+// A range that is guaranteed to contain pc and to be non-empty.
+//
+// old_interpreter releases the thread when (pc < begin || pc >= end), which is unconditionally true
+// for begin == end, so arming the fallback with an empty range makes the interpreter return without
+// executing an instruction while dispatch re-enters at an unchanged pc. Not every path into the
+// fallback has marked the block first: a compile can return null having produced no diagnostic, in
+// which case nothing was recorded and the lookup finds nothing.
+static std::pair<u32, u32> spu_arm_interp_fallback(u32 pc, u32 lower_bound, u32 size_bytes)
+{
+	// One critical section, not a lookup followed by a separate mark: with the two split, a
+	// concurrent clear landing in the gap would take the answer back to empty and hand the caller
+	// the range it must not have. Holding the writer lock throughout makes the guarantee
+	// structural rather than a property of who happens to call the reset today.
+	std::lock_guard lock(s_spu_failed_blocks_mutex);
+
+	if (const auto range = s_spu_failed_blocks.range_of(pc); range.second > range.first)
+	{
+		return range;
+	}
+
+	// Deliberately silent, and deliberately not routed through spu_mark_block_compile_failed.
+	//
+	// Reaching here means a compile returned null having reported nothing, which is not evidence
+	// that the backend cannot compile this block: an engine poisoned by an earlier fatal error, an
+	// analyser that produced no program for a wild branch into data, and a lost race for the
+	// compile claim all land here too. Recording the entry is still required, because the
+	// interpreter's release test needs a non-empty range -- but claiming a backend limitation in
+	// the log would send the next investigation at the wrong subsystem, and doing it once per four
+	// bytes of a walked region is the log flood this mechanism already had once.
+	//
+	// Record the analysed extent when the caller has one. Recording only [pc, pc + 4) instead
+	// makes the interpreter release the thread after a single instruction, whereupon dispatch
+	// re-enters four bytes later, finds that address unmarked, and pays another full analyse and
+	// another full failed compile -- the 4-bytes-at-a-time walk this file already documents at
+	// the top of the failed-block set.
+	if (size_bytes && pc >= lower_bound && pc - lower_bound < size_bytes)
+	{
+		s_spu_failed_blocks.mark(lower_bound, lower_bound + size_bytes);
+	}
+	else
+	{
+		s_spu_failed_blocks.mark(pc, pc + 4);
+	}
+
+	return s_spu_failed_blocks.range_of(pc);
+}
+
+// Run the uncompilable block here, inside the gateway invocation dispatch was called from.
+//
+// The interpreter used to be started from spu_thread::cpu_task, after dispatch had escaped. That
+// executed guest code outside any gateway call, while spu_runtime::g_escape resumes through the
+// gateway epilogue whose address and stack pointer the gateway prologue stored in hv_ctx. Those
+// describe a gateway call that has already returned, so an escape taken from inside the
+// interpreter -- a guest HALT, an MFC interrupt, cpu_work -- restored a stack pointer into a dead
+// frame. Running the interpreter from here keeps that frame live for as long as anything inside it
+// can escape.
+static void spu_run_interp_fallback(spu_thread& spu, u32 lower_bound = 0, u32 size_bytes = 0)
+{
+	std::tie(spu.interp_fallback_begin, spu.interp_fallback_end) =
+		spu_arm_interp_fallback(spu.pc, lower_bound, size_bytes);
+
+	// The release test below is (pc < begin || pc >= end); an empty range makes it true on the
+	// first iteration and the interpreter returns having executed nothing.
+	ensure(spu.interp_fallback_end > spu.interp_fallback_begin);
+
+	spu.interp_fallback = true;
+
+	// Matches the interpreter-only path in spu_thread::cpu_task, which enables interrupt servicing
+	// for as long as it is interpreting.
+	//
+	// Cleared by cpu_task before the next gateway entry, NOT restored around this call. A guest
+	// HALT, an MFC interrupt or cpu_work can escape from inside old_interpreter, and an escape is
+	// a far jump to the gateway epilogue that discards every frame in between without running one
+	// destructor or one further statement -- so anything written after this call is skipped on
+	// exactly the paths the flag is set for. cpu_task's loop is where control lands afterwards,
+	// and it runs on both the normal and the escaping path.
+	spu.allow_interrupts_in_cpu_work = true;
+
+	spu_recompiler_base::old_interpreter(spu, spu._ptr<u8>(0), nullptr);
+
+	spu_runtime::g_escape(&spu);
 }
 
 static spu_function_t compile_spu_llvm_with_retry(std::unique_ptr<spu_recompiler_base>& compiler, const spu_program& program)
@@ -1557,6 +1628,21 @@ bool spu_program::operator<(const spu_program& rhs) const noexcept
 
 spu_runtime::spu_runtime()
 {
+	// Drop the previous session's failed-block set.
+	//
+	// It is keyed on local-store offsets, which are per-thread 18-bit addresses that every SPU
+	// thread, every image and every title in the process reuse. Left in place, a block that failed
+	// to compile while one title ran would route a different title's unrelated code at the same
+	// offset to the interpreter for the rest of the process's life. This object is created per
+	// emulation session, so its constructor is where a session-scoped set is emptied. Above the
+	// early return below, which is taken when there is no cache path.
+	//
+	// Guarded because the set and its accessors only exist on ARM64: it is the backend that can
+	// fail to compile a block, so no other target has anything to reset.
+#ifdef ARCH_ARM64
+	spu_reset_failed_blocks();
+#endif
+
 	// Clear LLVM output
 	m_cache_path = rpcs3::cache::get_ppu_cache();
 
@@ -2502,9 +2588,7 @@ void spu_recompiler_base::dispatch(spu_thread& spu, void*, u8* rip)
 		// boundary constantly: God of War 3 wrote thousands of lines a second ping-ponging
 		// between two addresses, which cost more than the interpretation. The block is already
 		// recorded once by spu_mark_block_compile_failed.
-		std::tie(spu.interp_fallback_begin, spu.interp_fallback_end) = spu_block_failed_range(spu.pc);
-		spu.interp_fallback = true;
-		spu_runtime::g_escape(&spu);
+		spu_run_interp_fallback(spu);
 		return;
 	}
 #endif
@@ -2527,9 +2611,9 @@ void spu_recompiler_base::dispatch(spu_thread& spu, void*, u8* rip)
 #if defined(__APPLE__)
 			pthread_jit_write_protect_np(true);
 #endif
-			std::tie(spu.interp_fallback_begin, spu.interp_fallback_end) = spu_block_failed_range(spu.pc);
-			spu.interp_fallback = true;
-			spu_runtime::g_escape(&spu);
+			// The analysed extent is in scope here, so a block that reached the fallback without
+			// being recorded is still recorded whole rather than four bytes at a time.
+			spu_run_interp_fallback(spu, program.lower_bound, ::size32(program.data) * 4);
 			return;
 		}
 #endif
@@ -2691,11 +2775,14 @@ void spu_recompiler_base::old_interpreter(spu_thread& spu, void* ls, u8* /*rip*/
 		// slow, and these are SPURS kernels doing real work: Sonic Unleashed reached its loading
 		// screen that way and then crawled through it.
 		//
-		// The set holds entry points, so this keeps interpreting while pc sits on the bad entry
-		// -- which is where a branch-to-self idle loop stays -- and releases the thread once
-		// execution moves on. Leaving is safe at any instruction boundary, since all SPU state
-		// lives in spu_thread, the same assumption the JIT dispatch makes. Re-entering the bad
-		// block simply sets the flag again.
+		// The set holds ranges, so this keeps interpreting for the whole of the block that could
+		// not be compiled -- including a branch-to-self idle loop inside it -- and releases the
+		// thread once execution leaves that range. Leaving is safe at any instruction boundary,
+		// since all SPU state lives in spu_thread, the same assumption the JIT dispatch makes.
+		// Re-entering the bad block simply sets the flag again.
+		//
+		// The range is guaranteed non-empty by spu_arm_interp_fallback: begin == end would make
+		// this test true on the first iteration and return without executing an instruction.
 		if (spu.interp_fallback && (spu.pc < spu.interp_fallback_begin || spu.pc >= spu.interp_fallback_end)) [[unlikely]]
 		{
 			spu.interp_fallback = false;

--- a/rpcs3/Emu/Cell/SPUFailedBlocks.h
+++ b/rpcs3/Emu/Cell/SPUFailedBlocks.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <algorithm>
+#include <map>
+#include <utility>
+
+// Disjoint interval set over SPU local-store addresses, holding the ranges whose programs could
+// not be compiled by the recompiler backend.
+//
+// Disjointness is the load-bearing property, not an optimization. Both lookups locate a candidate
+// with upper_bound and step back exactly one entry, so they only ever examine a single range. That
+// is correct if and only if no range can hide another. It is not free: the two marking call sites
+// record different extents -- one records a whole analysed program, the other records only an entry
+// point when there is no program to describe -- so an entry-only mark landing inside a program-sized
+// mark is ordinary, and the entry-only one always ends first. With the ranges stored as inserted,
+// the shorter one wins the upper_bound step-back and the enclosing one becomes invisible for every
+// address past its end.
+//
+// mark() therefore merges on insert instead, so the invariant holds by construction and the cheap
+// lookup stays cheap. Header-only and free of engine dependencies so it can be tested directly
+// rather than through a model of it.
+class spu_failed_block_set
+{
+public:
+	// Record [begin, end). Returns true if this call actually grew the covered set, which is the
+	// condition worth logging: re-marking an already-covered block is the normal case and logging
+	// it floods (a title ping-ponging between two addresses produced thousands of lines a second).
+	bool mark(std::uint32_t begin, std::uint32_t end)
+	{
+		if (end <= begin)
+		{
+			// An empty range would be indistinguishable from "not found" at every reader.
+			return false;
+		}
+
+		if (auto covering = range_of(begin); covering.second >= end && covering.first <= begin)
+		{
+			return false;
+		}
+
+		// Absorb the left neighbour when it overlaps or merely touches, then every following range
+		// the widened interval reaches. Touching ranges are merged as well: they describe the same
+		// fact about adjacent code and keeping them apart only grows the map.
+		auto it = m_map.upper_bound(begin);
+
+		if (it != m_map.begin())
+		{
+			auto prev = std::prev(it);
+
+			if (prev->second >= begin)
+			{
+				begin = prev->first;
+				end = std::max(end, prev->second);
+				it = m_map.erase(prev);
+			}
+		}
+
+		while (it != m_map.end() && it->first <= end)
+		{
+			end = std::max(end, it->second);
+			it = m_map.erase(it);
+		}
+
+		m_map.emplace(begin, end);
+		return true;
+	}
+
+	// The range containing addr, or {0, 0}. A stored range always has end > begin, so {0, 0} is
+	// unambiguous.
+	std::pair<std::uint32_t, std::uint32_t> range_of(std::uint32_t addr) const
+	{
+		auto it = m_map.upper_bound(addr);
+
+		if (it == m_map.begin())
+		{
+			return {};
+		}
+
+		--it;
+
+		if (addr >= it->first && addr < it->second)
+		{
+			return {it->first, it->second};
+		}
+
+		return {};
+	}
+
+	bool contains(std::uint32_t addr) const
+	{
+		const auto range = range_of(addr);
+		return range.second > range.first;
+	}
+
+	void clear()
+	{
+		m_map.clear();
+	}
+
+	std::size_t size() const
+	{
+		return m_map.size();
+	}
+
+	// Test-only: verify the invariant every lookup depends on.
+	bool is_disjoint() const
+	{
+		std::uint32_t last_end = 0;
+		bool first = true;
+
+		for (const auto& [begin, end] : m_map)
+		{
+			if (end <= begin)
+			{
+				return false;
+			}
+
+			if (!first && begin <= last_end)
+			{
+				return false;
+			}
+
+			last_end = end;
+			first = false;
+		}
+
+		return true;
+	}
+
+private:
+	std::map<std::uint32_t, std::uint32_t> m_map;
+};

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1563,33 +1563,29 @@ void spu_thread::cpu_task()
 				continue;
 			}
 
-			if (interp_fallback) [[unlikely]]
-			{
-				allow_interrupts_in_cpu_work = true;
-
-				// Check the fallback is actually executing, once.
-				//
-				// This loop re-enters unconditionally, so if g_interpreter returns without
-				// running an instruction the pc never moves and the thread spins here in C++ at
-				// a fixed pc while looking like it is running. Sonic Unleashed's
-				// RsdxPrimaryCellSpursKernel4 sits at pc=0x07350 with interp_fb=1 and is the only
-				// SPU in the process using this path, which is what this distinguishes: a guest
-				// spin loop that legitimately waits, versus a fallback that executes nothing.
-				// The legacy C++ interpreter, NOT spu_runtime::g_interpreter.
-				//
-				// g_interpreter is the LLVM-built interpreter when a recompiler is selected, and
-				// on ARM64 calling it here executes nothing: measured a million consecutive calls
-				// on Sonic Unleashed's stuck SPURS kernel without pc moving once. The thread then
-				// spins in this loop forever at a fixed pc with no flags set, which looks like a
-				// busy SPU and hangs the title with no diagnostic. Any block that fails to compile
-				// lands here, so this is not one game's problem.
-				//
-				// old_interpreter is what the static decoder ultimately runs, via tr_interpreter,
-				// and it is self-contained. It loops until the thread is interrupted, which is the
-				// intended semantic: the THREAD switches to the interpreter, as the log says.
-				spu_recompiler_base::old_interpreter(*this, _ptr<u8>(0), nullptr);
-				continue;
-			}
+			// A block that cannot be compiled is interpreted by spu_run_interp_fallback, which
+			// runs inside the gateway call below rather than out here.
+			//
+			// It used to run here, after dispatch had escaped. The interpreter is self-contained
+			// and that part worked, but guest code then executed outside any gateway invocation
+			// while spu_runtime::g_escape resumes through the gateway epilogue recorded in
+			// hv_ctx -- belonging to a call that had already returned. A guest HALT, an MFC
+			// interrupt or cpu_work escaping from inside the interpreter restored a stack pointer
+			// into a dead frame.
+			//
+			// Note the fallback is NOT spu_runtime::g_interpreter: that is the LLVM-built
+			// interpreter used when a recompiler is selected, and on ARM64 calling it for this
+			// purpose executes nothing -- measured a million consecutive calls on Sonic
+			// Unleashed's stuck SPURS kernel without pc moving once.
+			//
+			// Both flags are cleared here rather than by the code that sets them. An escape taken
+			// from inside the fallback interpreter jumps to the gateway epilogue and abandons the
+			// frames that would have cleared them, so a thread that met one uncompilable block
+			// would otherwise run every later JIT block with interrupt servicing enabled and
+			// report itself as interpreting for the rest of its life. This is the one point every
+			// escape returns through.
+			interp_fallback = false;
+			allow_interrupts_in_cpu_work = false;
 
 			spu_runtime::g_gateway(*this, _ptr<u8>(0), nullptr);
 		}

--- a/rpcs3/tests/rpcs3_test.vcxproj
+++ b/rpcs3/tests/rpcs3_test.vcxproj
@@ -97,6 +97,7 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="test_spu_analyser.cpp" />
+    <ClCompile Include="test_spu_failed_blocks.cpp" />
     <ClCompile Include="test_fmt.cpp" />
     <ClCompile Include="test_rsx_cfg.cpp" />
     <ClCompile Include="test_rsx_fp_asm.cpp" />

--- a/rpcs3/tests/test_spu_failed_blocks.cpp
+++ b/rpcs3/tests/test_spu_failed_blocks.cpp
@@ -1,0 +1,281 @@
+#include <gtest/gtest.h>
+
+#include "Emu/Cell/SPUFailedBlocks.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+// Both lookups in spu_failed_block_set locate a candidate with upper_bound and step back exactly
+// one entry, so they only ever examine a single range. That is correct if and only if no stored
+// range can hide another, which is what this file pins down.
+//
+// What rejects what, measured rather than asserted:
+//
+//   EntryOnlyMarkInsideProgramMarkStaysVisible is the hole detector. Revert mark() to a plain
+//   insert keyed on begin and its contains() expectations fail.
+//
+//   MatchesReferenceCoverage is the oracle. It compares the set against an independent bitmap over
+//   a small address space, so it constrains the union, the maximality of range_of and the
+//   "coverage grew" return value at once, for sequences nobody chose by hand. It is what rejects a
+//   merge that is subtly wrong rather than absent.
+//
+//   is_disjoint() is a witness, not a test. Through this class's public API no sequence can
+//   produce a non-disjoint state, so every EXPECT on it passes unconditionally and would keep
+//   passing if its body were replaced by `return true`. It is retained because it localises a
+//   future regression, NOT because it demonstrates anything here; MatchesReferenceCoverage is the
+//   check with a demonstrated negative.
+//
+// Not covered by this file, and not coverable from it: spu_arm_interp_fallback,
+// spu_run_interp_fallback, spu_interpreter_fallback_available, the per-session reset in the
+// spu_runtime constructor, and every escape path out of the fallback interpreter. Those need a
+// spu_thread and a live gateway frame. Their absence here is not evidence about them.
+
+namespace
+{
+	// Independent of the implementation: a flat bitmap of "is this address covered".
+	class reference_coverage
+	{
+	public:
+		explicit reference_coverage(std::uint32_t limit)
+			: m_covered(limit, false)
+		{
+		}
+
+		void mark(std::uint32_t begin, std::uint32_t end)
+		{
+			for (std::uint32_t a = begin; a < end && a < m_covered.size(); ++a)
+			{
+				m_covered[a] = true;
+			}
+		}
+
+		bool contains(std::uint32_t addr) const
+		{
+			return addr < m_covered.size() && m_covered[addr];
+		}
+
+		std::size_t count() const
+		{
+			std::size_t n = 0;
+			for (bool b : m_covered) n += b ? 1 : 0;
+			return n;
+		}
+
+		// The maximal contiguous covered interval containing addr, or {0,0}.
+		std::pair<std::uint32_t, std::uint32_t> range_of(std::uint32_t addr) const
+		{
+			if (!contains(addr))
+			{
+				return {};
+			}
+
+			std::uint32_t b = addr;
+			while (b > 0 && m_covered[b - 1]) --b;
+
+			std::uint32_t e = addr + 1;
+			while (e < m_covered.size() && m_covered[e]) ++e;
+
+			return {b, e};
+		}
+
+	private:
+		std::vector<bool> m_covered;
+	};
+}
+
+TEST(SPUFailedBlocks, EntryOnlyMarkInsideProgramMarkStaysVisible)
+{
+	spu_failed_block_set set;
+
+	// An analysed program that could not be compiled records its whole extent; a path with no
+	// program to describe records the entry alone. The entry-only range always ends first, so
+	// stored as-is it wins the upper_bound step-back and hides the enclosing one.
+	EXPECT_TRUE(set.mark(0x5370, 0x5374));
+	EXPECT_TRUE(set.mark(0x5000, 0x6000));
+
+	EXPECT_TRUE(set.contains(0x5000));
+	EXPECT_TRUE(set.contains(0x5372));
+	EXPECT_TRUE(set.contains(0x5800));
+	EXPECT_TRUE(set.contains(0x5fff));
+
+	EXPECT_EQ(set.range_of(0x5800), std::make_pair(0x5000u, 0x6000u));
+	EXPECT_TRUE(set.is_disjoint());
+}
+
+TEST(SPUFailedBlocks, OverlappingProgramMarksStayVisible)
+{
+	spu_failed_block_set set;
+
+	EXPECT_TRUE(set.mark(0x7000, 0x7400));
+	// A smaller program starting inside the first one. The coverage expectations come first
+	// deliberately: an ASSERT here would abort the case before them, and they are the property
+	// worth measuring.
+	const bool grew = set.mark(0x7100, 0x7140);
+
+	EXPECT_TRUE(set.contains(0x7120));
+	EXPECT_TRUE(set.contains(0x7200));
+	EXPECT_TRUE(set.contains(0x7380));
+	EXPECT_TRUE(set.is_disjoint());
+
+	// Already inside a stored range, so nothing was added and the caller must not log.
+	EXPECT_FALSE(grew);
+}
+
+TEST(SPUFailedBlocks, MatchesReferenceCoverage)
+{
+	// Deterministic LCG rather than <random>, so the sequence is identical everywhere.
+	std::uint32_t rng = 0x1234567u;
+	const auto next = [&rng](std::uint32_t bound)
+	{
+		rng = rng * 1664525u + 1013904223u;
+		return (rng >> 16) % bound;
+	};
+
+	constexpr std::uint32_t limit = 512;
+
+	for (int trial = 0; trial < 200; ++trial)
+	{
+		spu_failed_block_set set;
+		reference_coverage ref(limit);
+
+		for (int op = 0; op < 24; ++op)
+		{
+			const std::uint32_t begin = next(limit);
+			// Clamped to the bitmap. Without this the set legitimately covers past the reference's
+			// last address and every comparison near the top reports a mismatch that is the
+			// oracle's, not the implementation's.
+			const std::uint32_t end = std::min(begin + next(40), limit);
+
+			const std::size_t before = ref.count();
+			const bool grew = set.mark(begin, end);
+			ref.mark(begin, end);
+
+			// The return value drives whether the caller logs, so it has to mean exactly
+			// "the covered set grew".
+			ASSERT_EQ(grew, ref.count() != before)
+				<< "trial " << trial << " op " << op << " [" << begin << "," << end << ")";
+		}
+
+		ASSERT_TRUE(set.is_disjoint()) << "trial " << trial;
+
+		for (std::uint32_t a = 0; a < limit; ++a)
+		{
+			ASSERT_EQ(set.contains(a), ref.contains(a)) << "trial " << trial << " addr " << a;
+			ASSERT_EQ(set.range_of(a), ref.range_of(a)) << "trial " << trial << " addr " << a;
+		}
+	}
+}
+
+TEST(SPUFailedBlocks, EveryStoredRangeIsNonEmpty)
+{
+	spu_failed_block_set set;
+
+	// An empty range is indistinguishable from "not found" at every reader.
+	EXPECT_FALSE(set.mark(0x100, 0x100));
+	EXPECT_FALSE(set.mark(0x200, 0x100));
+	EXPECT_EQ(set.size(), 0u);
+	EXPECT_FALSE(set.contains(0x100));
+
+	EXPECT_TRUE(set.mark(0x100, 0x104));
+	const auto range = set.range_of(0x100);
+	EXPECT_GT(range.second, range.first);
+}
+
+TEST(SPUFailedBlocks, BoundariesAreHalfOpen)
+{
+	spu_failed_block_set set;
+	EXPECT_TRUE(set.mark(0x1000, 0x1010));
+
+	EXPECT_FALSE(set.contains(0x0fff));
+	EXPECT_TRUE(set.contains(0x1000));
+	EXPECT_TRUE(set.contains(0x100f));
+	EXPECT_FALSE(set.contains(0x1010));
+}
+
+TEST(SPUFailedBlocks, TouchingRangesMergeFromTheLeft)
+{
+	spu_failed_block_set set;
+
+	EXPECT_TRUE(set.mark(0x1000, 0x2000));
+	EXPECT_TRUE(set.mark(0x2000, 0x3000));
+
+	EXPECT_EQ(set.size(), 1u);
+	EXPECT_EQ(set.range_of(0x2800), std::make_pair(0x1000u, 0x3000u));
+	EXPECT_TRUE(set.is_disjoint());
+}
+
+TEST(SPUFailedBlocks, TouchingRangesMergeFromTheRight)
+{
+	// The mirror of the case above. Absorbing a left neighbour and absorbing following neighbours
+	// are two different branches of mark(); one order exercises only one of them.
+	spu_failed_block_set set;
+
+	EXPECT_TRUE(set.mark(0x2000, 0x3000));
+	EXPECT_TRUE(set.mark(0x1000, 0x2000));
+
+	EXPECT_EQ(set.size(), 1u);
+	EXPECT_EQ(set.range_of(0x2800), std::make_pair(0x1000u, 0x3000u));
+	EXPECT_TRUE(set.is_disjoint());
+}
+
+TEST(SPUFailedBlocks, AlreadyCoveredMarkReportsNoGrowth)
+{
+	spu_failed_block_set set;
+
+	EXPECT_TRUE(set.mark(0x1000, 0x2000));
+
+	// The caller logs on a true return. Re-marking a covered block is the normal case -- a title
+	// ping-ponging between two addresses inside one bad block -- and must stay silent.
+	EXPECT_FALSE(set.mark(0x1400, 0x1500));
+	EXPECT_FALSE(set.mark(0x1000, 0x2000));
+	EXPECT_EQ(set.size(), 1u);
+}
+
+TEST(SPUFailedBlocks, WideMarkAbsorbsSeveralRanges)
+{
+	spu_failed_block_set set;
+
+	EXPECT_TRUE(set.mark(0x1000, 0x1100));
+	EXPECT_TRUE(set.mark(0x1200, 0x1300));
+	EXPECT_TRUE(set.mark(0x1400, 0x1500));
+	EXPECT_EQ(set.size(), 3u);
+
+	EXPECT_TRUE(set.mark(0x1050, 0x1450));
+
+	EXPECT_EQ(set.size(), 1u);
+	EXPECT_EQ(set.range_of(0x1350), std::make_pair(0x1000u, 0x1500u));
+	EXPECT_TRUE(set.contains(0x1180));
+	EXPECT_TRUE(set.is_disjoint());
+}
+
+TEST(SPUFailedBlocks, ClearEmptiesTheSet)
+{
+	spu_failed_block_set set;
+
+	EXPECT_TRUE(set.mark(0x7000, 0x8000));
+	EXPECT_TRUE(set.contains(0x7500));
+
+	set.clear();
+
+	EXPECT_EQ(set.size(), 0u);
+	EXPECT_FALSE(set.contains(0x7500));
+	EXPECT_EQ(set.range_of(0x7500), std::make_pair(0u, 0u));
+}
+
+TEST(SPUFailedBlocks, LocalStoreExtremesAreRepresentable)
+{
+	spu_failed_block_set set;
+
+	// Local store is 0x40000 bytes; the last instruction slot is 0x3fffc and an entry-only mark
+	// records [pc, pc + 4).
+	EXPECT_TRUE(set.mark(0x3fffc, 0x40000));
+
+	EXPECT_TRUE(set.contains(0x3fffc));
+	EXPECT_FALSE(set.contains(0x40000));
+	EXPECT_EQ(set.range_of(0x3fffc), std::make_pair(0x3fffcu, 0x40000u));
+
+	EXPECT_TRUE(set.mark(0, 4));
+	EXPECT_TRUE(set.contains(0));
+	EXPECT_TRUE(set.is_disjoint());
+}


### PR DESCRIPTION
## What it does

Fixes five defects in the ARM64 uncompilable-block SPU fallback introduced by 431b6d092 / 954337866 / 8c707648c / 38424a59b, and gives the failed-block set a tested implementation.

The mechanism: when the ARM64 LLVM backend cannot compile an SPU block, the block is recorded and its thread switches to `old_interpreter` instead of taking the `"Compilation failed"` fatal. What was wrong with it:

1. **The failed-block set was not disjoint, and both of its lookups assume it is.** They locate a candidate with `upper_bound` and step back exactly one entry, so they only ever examine a single range. The two marking call sites record different extents — one a whole analysed program, the other an entry point alone when there is no program to describe — so an entry-only mark landing inside a program-sized mark is ordinary, and it always ends first. Stored as inserted, the shorter one wins the step-back and the enclosing range becomes invisible for every address past its end. `mark()` now merges on insert, so the invariant holds by construction.

2. **A hole armed the interpreter with an empty range.** `old_interpreter` releases the thread when `(pc < begin || pc >= end)`, which is unconditionally true for `begin == end`, so it would return having executed nothing while dispatch re-entered at an unchanged `pc`. `spu_arm_interp_fallback` now returns a range that contains `pc` and is non-empty, recording the block first when no path had recorded it.

3. **The interpreter ran outside any gateway invocation.** It was started from `spu_thread::cpu_task` after dispatch had already escaped, while `spu_runtime::g_escape` resumes through the gateway epilogue whose address and stack pointer the prologue stored in `hv_ctx` — belonging to a call that has already returned. A guest `HALT`, an MFC interrupt or `cpu_work` escaping from inside the interpreter would restore a stack pointer into a dead frame. It now runs from dispatch, inside the live gateway call.

4. **`spu_interpreter_fallback_available()` tested the wrong object.** It checked `spu_runtime::g_interpreter`, the LLVM-built interpreter used when a recompiler is selected. The fallback actually run is `old_interpreter`, which reads the opcode table, the thread and the local store and nothing else. When the LLVM interpreter failed to build, the check disabled a fallback that was in fact available and dispatch took the fatal path instead.

5. **The set outlived the emulation session.** Its keys are local-store offsets, which every SPU thread, every image and every title in the process reuse, so one title's compile failures could route an unrelated title's code at the same offset to the interpreter. Cleared per session now, guarded by `ARCH_ARM64` since the set exists only on that backend.

Also: the fallback recorded only `[pc, pc + 4)` while dispatch was holding the analysed program, so the interpreter released the thread after one instruction and dispatch re-entered four bytes later to pay another full analyse and another full failed compile — the 4-bytes-at-a-time walk documented at the top of the file. The extent is passed through when the caller has one. That path also no longer logs `"cannot be compiled on this backend"`, because a null compile with no diagnostic covers a poisoned engine, an analyser that produced nothing for a branch into data, and a lost compile claim, none of which are backend limits.

The set moves into `spu_failed_block_set` (`SPUFailedBlocks.h`), header-only and free of engine dependencies so it can be exercised directly rather than through a model of it.

## How this was found

Fallout from chasing the Tom Clancy's H.A.W.X. 2 (BLES00928) boot hang, where an SPU thread parks forever at the first intro video. Reading the SPU dispatch path to work out how a thread ends up parked surfaced this fallback, added a few days earlier, and the defects above.

**This does not fix H.A.W.X. 2**, and it is not related to that hang — that one is a 16 KB MFC `GET` from EA 0 on `CellSpursKernel0`, which takes an access violation and sets `cpu_flag::dbg_pause` with nothing in the Android build able to clear it. It is a separate, still-open problem (and an open upstream RPCS3 issue for the same title). Only the code reading is shared.

## Testing

**Executed:**

- ARM64 core builds clean, no warnings.
- The interval set passes a randomized differential run directly on the header — 200 trials, 4800 `mark` operations against an independent bitmap oracle, 0 mismatches. The pre-merge algorithm fails the same oracle 1268 times.
- On device (AYN Odin 3, Snapdragon 8 Elite class, Android 15) the fallback path executed end to end for the first time. Nothing in the test library reaches it naturally — Safe, Mega and Giga all compile clean on both titles — so a **throwaway** build forced compile failures at dispatch, gated on a budget file so the same binary provides the control leg:
  - **Control** (budget file absent): stock behaviour, instrument prints `no budget file`, 76 present frames.
  - **Mirror's Edge, forced:** a block with no prior mark recorded its whole 680-byte analysed extent in a single mark — `marked pc=0x24978 lb=0x24978 size=680 -> range [0x24978,0x24c20) ranges=1` — was interpreted inside the live gateway frame, escaped, and the title screen held at 30.00 fps for 6 minutes.
  - **Metal Gear Rising (BLUS31045), forced:** a pre-marked block returned its covering range `[0x095d4,0x09620)`, interpreted and escaped; 457 present frames over 8m44s, VBlank 55875 iterations, zero `"Compilation failed"`.

**Not executed:**

- No x86-64 build and no `rpcs3_test` binary. The header's evidence comes from a standalone host harness and mutation runs, not from the registered gtest, and the `ARCH_ARM64` guard on the session reset is unverified by compilation. CI will be the first thing to compile that target.
- The dispatch re-entry fast path recorded **zero** hits in every device leg, so the exposure from merging ranges — previously-JIT'd addresses routed to the interpreter for the rest of the session — is unmeasured.
- The same forced failure applied to the pre-change code **did not fail on device either** (469 present frames, 8m53s, alive). These runs show the new path is correct and costs nothing; they do not show it is necessary. The escape from a dead gateway frame needs a `HALT`, an MFC interrupt or `cpu_work` to fire while inside the interpreter, which one short interpreted block did not reach.
- The branch is rebased onto `master`; every build and device run above was on a base that also carried #55's two commits. The commit's patch is unchanged, but nothing has been compiled or run on this exact base.

## Notes

- Budgets of 8 and 64 forced failures both produced exactly **one** engagement per run: almost every block is compiled by the background `spu_llvm` worker, so dispatch reaching a compile is rare, and the on-disk SPU cache removes most of what remains. Raising the budget does nothing; clearing the title's cache first is the untried lever for anyone wanting more coverage of this path.
- `tests/test_spu_failed_blocks.cpp` is registered in `rpcs3_test.vcxproj` as well as the CMake list — the Windows CI job runs the MSVC build, where it would otherwise have been absent while reporting green. `is_disjoint()` has no reachable negative through the public API and is documented as a witness rather than presented as a check.
- ARM64 only; no other backend has a failed-block set to keep or reset.
