### PR TITLE
Bundle the H.A.W.X. 2 Bink overlay patch and enable it

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -1803,13 +1803,6 @@ static void append_patches(patch_engine::patch_map& existing_patches, const patc
 
 bool patch_engine::save_patches(const patch_map& patches, const std::string& path, std::stringstream* log_messages)
 {
-	fs::file file(path, fs::rewrite);
-	if (!file)
-	{
-		append_log_message(log_messages, fmt::format("Failed to open patch file %s (%s)", path, fs::g_tls_error), &patch_log.fatal);
-		return false;
-	}
-
 	YAML::Emitter out;
 	out << YAML::BeginMap;
 	out << patch_key::version << patch_engine_version;
@@ -1904,7 +1897,24 @@ bool patch_engine::save_patches(const patch_map& patches, const std::string& pat
 				out << YAML::Flow;
 				out << YAML::BeginSeq;
 				out << fmt::format("%s", data.type);
-				out << fmt::format("0x%.8x", data.offset);
+
+				// move_file and hide_file carry a VFS path in the address element instead of a
+				// number. load() keeps that text in original_offset and skips the u32 validation for
+				// them, so formatting it numerically here would write out 0x00000000 and the loader
+				// would accept it back as a patch that silently never matches anything.
+				//
+				// The numeric branch deliberately uses offset rather than original_offset: an
+				// address modifier is folded into offset at load time, and the flat form emitted
+				// here has nowhere to put it.
+				if (patch_type_uses_hex_offset(data.type))
+				{
+					out << fmt::format("0x%.8x", data.offset);
+				}
+				else
+				{
+					out << data.original_offset;
+				}
+
 				out << data.original_value;
 				out << YAML::EndSeq;
 			}
@@ -1918,7 +1928,17 @@ bool patch_engine::save_patches(const patch_map& patches, const std::string& pat
 
 	out << YAML::EndMap;
 
-	file.write(out.c_str(), out.size());
+	// Write through a temporary and rename on success, as save_config already does. A truncating
+	// in-place write that fails part way (out of space, process killed) leaves a half-written file,
+	// and load() rejects the whole file on a parse error -- so a failure here costs the user every
+	// patch they had, with no way to rebuild it from inside the app.
+	fs::pending_file file(path);
+
+	if (!file.file || file.file.write(out.c_str(), out.size()) < out.size() || !file.commit())
+	{
+		append_log_message(log_messages, fmt::format("Failed to write patch file %s (%s)", path, fs::g_tls_error), &patch_log.fatal);
+		return false;
+	}
 
 	return true;
 }

--- a/android/armsx3-ui/app/src/main/assets/canary_patches.yml
+++ b/android/armsx3-ui/app/src/main/assets/canary_patches.yml
@@ -50,3 +50,44 @@ PPU-4b46d0161ca657ab16b0a779d9062810ea5ea2dd:
       - [ jumpf, 0x00000000, "RPCS3_HLE_LIBRARY:WaitForSPUsToEmptySNRs" ] # Args: (SPU ID, 3)
       - [ be32, 0x00000000, 0x38800000 ] # li r4, 0
       - [ be32, 0x00000000, 0x44000002 ] # sc
+
+# Tom Clancy's H.A.W.X. 2 (BLES00928) -- boot hang at the first intro video.
+#
+# The SPU dies with "Access violation reading location 0x20" in CellSpursKernel0 and
+# is parked forever (dbg_pause, which nothing in the Android build can clear), so the
+# emulator looks healthy at a locked 30 fps while the guest is dead. Upstream RPCS3
+# lists the title as Loadable with no fix but "delete data/movies".
+#
+# The title looks up a section named '.reload' in this SPU module. The module is
+# stripped -- e_shnum = 0 -- so the lookup can never succeed, on hardware either, and
+# the game is built to cope: the failure path writes 0 to the work descriptor's +0x10
+# field, and this very module tests that field to skip the overlay load:
+#
+#   03224  lqr r8,0x1b810     ; r8 = desc[+0x10]
+#   0322c  brz r8,0x32cc      ; == 0 -> skip
+#
+# A bump allocator on the PPU side then runs over the field unconditionally --
+# (0 - 0x10) & ~0xF = 0xfffffff0 -- destroying the sentinel. The guard no longer
+# fires, so the SPU issues GET lsa=0 ea=0 size=0x4000, a transfer that would have
+# overwritten the running SPURS kernel had it succeeded.
+#
+# This makes the overlay routine at LS 0x3208 return immediately, which is what the
+# surviving guard would have caused anyway. Safe because the section it needs cannot
+# exist in a stripped module. Suppressing the DMA instead does NOT work: the guest
+# loop waits on data that never arrives and runs away.
+#
+# Ps3PatchRepo.BUNDLED must list this, or it is imported but never enabled.
+
+SPU-42bae8e5d6a9304068ba1c6bbfdc18d656e287a1:
+  Bink overlay skip:
+    Games:
+      "Tom Clancy's H.A.W.X. 2":
+        BLES00928:
+          - "All"
+    Author: Zulux91
+    Patch Version: 1.0
+    Notes: Fixes the boot hang at the first intro video.
+    Patch:
+      # LS 0x3208 is the first instruction of the overlay routine (il r5,0).
+      # Offsets are LS addresses: apply_modification subtracts p_vaddr (0x3000).
+      - [ be32, 0x3208, 0x35000000 ] # bi lr -- return immediately

--- a/android/armsx3-ui/app/src/main/java/com/armsx2/Ps3PatchRepo.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/Ps3PatchRepo.kt
@@ -188,6 +188,14 @@ object Ps3PatchRepo {
             serial = "BLUS30008",
             appVersion = "01.01",
         ),
+        // Tom Clancy's H.A.W.X. 2, BLES00928 -- without this the game hangs forever at
+        // the first intro video with a dead SPU. See canary_patches.yml.
+        Bundled(
+            hash = "SPU-42bae8e5d6a9304068ba1c6bbfdc18d656e287a1",
+            name = "Bink overlay skip",
+            serial = "BLES00928",
+            appVersion = "All",
+        ),
     )
 
     private const val BUNDLED_ASSET = "canary_patches.yml"
@@ -197,7 +205,7 @@ object Ps3PatchRepo {
      * install re-imports and enables the new ones. Not a timestamp: it has to be
      * something a diff of this file makes obvious.
      */
-    private const val BUNDLED_REVISION = 1
+    private const val BUNDLED_REVISION = 2
 
     private const val PREFS_NAME = "ARMSX2"
     private const val KEY_BUNDLED_REVISION = "ps3_bundled_patch_revision"

--- a/android/armsx3-ui/app/src/main/java/com/armsx2/Ps3PatchRepo.kt
+++ b/android/armsx3-ui/app/src/main/java/com/armsx2/Ps3PatchRepo.kt
@@ -171,12 +171,18 @@ object Ps3PatchRepo {
      *
      * appVersion is carried for symmetry with [Patch]; the native side matches on
      * serial and ignores it.
+     *
+     * sinceRevision is the [BUNDLED_REVISION] this entry first shipped in. It is what
+     * keeps a bump from touching the patches that were already here: an install whose
+     * stored revision is at or above it has been offered this patch once already, and
+     * whatever the user did with the toggle afterwards is their answer.
      */
     private data class Bundled(
         val hash: String,
         val name: String,
         val serial: String,
         val appVersion: String,
+        val sinceRevision: Int,
     )
 
     private val BUNDLED = listOf(
@@ -187,6 +193,7 @@ object Ps3PatchRepo {
             name = "Graphics Fix",
             serial = "BLUS30008",
             appVersion = "01.01",
+            sinceRevision = 1,
         ),
         // Tom Clancy's H.A.W.X. 2, BLES00928 -- without this the game hangs forever at
         // the first intro video with a dead SPU. See canary_patches.yml.
@@ -195,6 +202,7 @@ object Ps3PatchRepo {
             name = "Bink overlay skip",
             serial = "BLES00928",
             appVersion = "All",
+            sinceRevision = 2,
         ),
     )
 
@@ -218,9 +226,10 @@ object Ps3PatchRepo {
      * tick a box before Sonic '06 renders has already concluded the emulator is
      * broken.
      *
-     * Guarded by a stored revision rather than run every boot, so turning one OFF
-     * sticks. Re-enabling on every launch would make the toggle look broken, which
-     * is the same class of bug as not having the patch at all.
+     * Only patches newer than the stored revision are touched, so turning one OFF
+     * sticks -- including across a later bump made for some other game. Re-enabling
+     * on every launch, or on every bump, would make the toggle look broken, which is
+     * the same class of bug as not having the patch at all.
      *
      * Safe to call on every boot: it is a preference read once the revision matches,
      * and the import itself merges rather than replaces, so a downloaded database
@@ -228,7 +237,21 @@ object Ps3PatchRepo {
      */
     fun ensureBundledPatches(context: Context) {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        if (prefs.getInt(KEY_BUNDLED_REVISION, 0) >= BUNDLED_REVISION) return
+        val storedRevision = prefs.getInt(KEY_BUNDLED_REVISION, 0)
+        if (storedRevision >= BUNDLED_REVISION) return
+
+        // Anything at or below the stored revision has had its one chance to be turned
+        // on. Re-enabling it here would silently undo a user's OFF, and patch_config.yml
+        // stores "disabled" as an absent entry, so there is nothing to read back that
+        // would tell us the difference between "opted out" and "never seen".
+        val pending = BUNDLED.filter { it.sinceRevision > storedRevision }
+
+        if (pending.isEmpty()) {
+            // Nothing new to enable, so skip the import entirely rather than rewriting
+            // patches/patch.yml for no reason.
+            prefs.edit().putInt(KEY_BUNDLED_REVISION, BUNDLED_REVISION).apply()
+            return
+        }
 
         val yaml = runCatching {
             context.assets.open(BUNDLED_ASSET).bufferedReader().use { it.readText() }
@@ -249,8 +272,10 @@ object Ps3PatchRepo {
 
         // Only mark the revision done if every patch actually turned on. A failure
         // here means the hash or name drifted from the YAML, and retrying next boot
-        // is better than silently shipping a game that does not render.
-        val allEnabled = BUNDLED.all { b ->
+        // is better than silently shipping a game that does not render. The retry
+        // covers only `pending`, so a patch that is stuck failing cannot drag the
+        // already-settled ones back on every boot with it.
+        val allEnabled = pending.all { b ->
             val ok = runCatching {
                 RPCSX.instance.patchSetEnabled(b.hash, b.name, b.serial, b.appVersion, true)
             }.getOrDefault(false)
@@ -262,7 +287,7 @@ object Ps3PatchRepo {
 
         if (allEnabled) {
             prefs.edit().putInt(KEY_BUNDLED_REVISION, BUNDLED_REVISION).apply()
-            android.util.Log.i("ARMSX3", "canary patches: imported $imported, enabled ${BUNDLED.size}")
+            android.util.Log.i("ARMSX3", "canary patches: imported $imported, enabled ${pending.size}")
         }
     }
 }


### PR DESCRIPTION
## What it does

Bundles a canary patch that fixes **Tom Clancy's H.A.W.X. 2 (BLES00928)**, which hangs forever at the first intro video, and enables it — same mechanism as the Sonic '06 fix in 3f91dfa.

Without it the SPU dies with `Access violation reading location 0x20` in `CellSpursKernel0` and is parked with `cpu_flag::dbg_pause`, which nothing in the Android build can clear. The emulator looks healthy — locked 30 fps, VBlank running, RSX presenting — while guest RSX utilisation sits at 0% and the guest is dead. Reproduced 6/6.

Upstream RPCS3 lists BLES00928 as **Loadable**, and the forums report the identical fault with the same "delete `data/movies`" workaround. With this patch the title boots, plays its intro cinematic, reaches the title screen and renders the first mission's targeting-pod sequence.

## Root cause

Everything below is measured on device, not inferred. Full write-up with raw output: `docs/adversarial/ledger/hawx2-bink-overlay-sentinel.md` (not in this PR).

**1. The game looks up an SPU ELF section that cannot exist.**

It searches an SPU module embedded in its own EBOOT for a section named `.reload`:

```
image=0x00ccee00  wanted='.reload'
e_type=2 (ET_EXEC) e_machine=23 (EM_SPU) e_phoff=0x34 e_phentsize=32 e_phnum=3
e_shoff=0x0  e_shentsize=40  e_shnum=0  e_shstrndx=0
```

The lookup is a textbook `Elf32_Ehdr`/`Elf32_Shdr` walk (`e_shoff` +0x20, `e_shnum` +0x30, `e_shstrndx` +0x32, stride 0x28, `sh_offset` +0x10) and **`e_shnum` is 0**.

The module is genuinely stripped on disc — this is not an emulator artifact:
- it lives inside the EBOOT's first LOAD segment (`p_vaddr=0x10000, p_filesz=p_memsz=0xd40a68`, fully file-backed);
- `PPUModule.cpp` only *scans* embedded SPU images ("we are not loading it") and never rewrites them — it reports `SPUNAME '../../TempBuild/Lib Release PS3/'`, `image addr 0xccee00, size 0x18820`;
- the string `.reload` appears nowhere in the extracted module image, nor in any file under `USRDIR`.

**So the lookup fails on real hardware too, and the game is built to cope with that.**

**2. The guest's own tolerance mechanism gets destroyed.**

The lookup's failure path writes `0` to the work descriptor's `+0x10` field (`0x00b2b19c`), and the SPU module tests exactly that field to decide whether an overlay needs loading:

```
03224  lqr r8,0x1b810     ; r8 = desc[+0x10]
0322c  brz r8,0x32cc      ; == 0 -> SKIP the overlay load
```

But the PPU caller then runs a bump allocator over that field **unconditionally** — there is no check of the lookup's return value between the call at `0x00b2a934` and the arithmetic:

```
00b2a95c  lwz    r4,0x80(r29)     ; r4 = [desc+0x10] = 0
00b2a968  addi   r9,-0x10(r4)     ; r9 = -0x10
00b2a970  rlwinm r26,r9,0,0,27    ; & ~0xF -> 0xfffffff0
00b2a974  stw    r26,0x80(r29)    ; desc[+0x10] = 0xfffffff0
```

The "nothing to load" sentinel is gone, the guard stops firing, and the SPU issues `GET lsa=0 ea=0 size=0x4000` in a chunked loop. Note that transfer targets LS `0..0x4000` — had it *succeeded* it would have overwritten the running SPURS kernel, which is independent evidence that hardware never takes this branch.

**3. Publish order rules out a race.** Measured in one run:

```
21.803896  +0x10 = 0            failure path writes the sentinel
21.806542  +0x10 = 0xfffffff0   allocator destroys it 2.6 ms later
22.536759  +0x04 = 2            "ready" flag published 0.73 s AFTER
```

The SPU waits on the ready flag, so it can never observe the sentinel intact. The guest deterministically publishes a self-inconsistent descriptor — there is no ordering for an emulator to get right, which is why this is a guest patch rather than a core fix.

## The patch

```yaml
SPU-42bae8e5d6a9304068ba1c6bbfdc18d656e287a1:
  Bink overlay skip:
    Games:
      "Tom Clancy's H.A.W.X. 2":
        BLES00928:
          - "All"
    Patch:
      - [ be32, 0x3208, 0x35000000 ] # bi lr -- return immediately
```

LS `0x3208` is the first instruction of the overlay routine (`il r5,0`, verified as `0x40800005` before writing). `0x35000000` is `bi lr`, taken from measured disassembly rather than hand-encoded. Offsets are LS addresses: `apply_modification` does `offset -= min_addr` with `min_addr = p_vaddr = 0x3000`, and PT_LOAD[0] is `p_filesz=0x186f0`, so `0x3208` lands inside it.

Making the routine return immediately is what the surviving guard would have caused anyway. It is keyed on the SPU image hash, so it cannot affect another title, or a build of this module that does carry sections.

## Alternatives that were tried and do not work

Recording these because they look plausible and each was refuted on device — relevant to anyone considering a core-side fix:

| Attempt | Result |
|---|---|
| Swallow the unmapped-EA DMA in `process_mfc_cmd` | SPU survives, but the guest loop waits on data that never arrives and **runs away** — 12+ chunks with EA climbing to `0x015ac000`, then a second access violation at `0xd0000020`. Game still does not boot. |
| Fill local store with a non-zero pattern (theory: hardware leaves garbage where RPCS3 zero-fills) | `CellSpursKernel0` trips its **own HALT assertion** at LS `0x18850` at t=12.9 s, *earlier* than the fault it was meant to prevent. 0 halts in 4 pre-fill runs, so the fill caused it. `LS[0..0x40]` must be zero for this kernel. |
| NOP the PPU store that destroys the sentinel (`0x00b2a974`) | `desc+0x10` correctly stays 0, but downstream PPU code consumes the updated value: `[00b2a998] stw r3,-0x6300(r23)` faults writing `0x20017`, "Emulation has been frozen". |
| Blame the tag on `desc+0x14` for selecting the faulting routine | `tag = (abs(r30^r28)-1 < 0 ? 4 : 0) + 2`, and `r30`/`r28` are literal zeros in game code (`li r4,0; li r5,0` at `0x00620464`) — tag 6 is by design, not a divergence. |

## Verification

Built with every diagnostic reverted (probe-marker `grep -c` on the APK's `.so` = 0) and default settings — `PPU/SPU Decoder: Recompiler (LLVM)`, `Accurate SPU DMA: false`, `PPU Debug: false`.

Device reset to the untouched 468-byte `patch.yml` stub with no `patch_config.yml` and `ps3_bundled_patch_revision` back to 1, so only the bundled path could work:

```
ARMSX3: canary patches: imported 1, enabled 2
patch.yml  468 -> 761 bytes    (merged; the existing Sonic entry preserved)
patch_config.yml created, both patches enabled

·S PAT: Applied patch (hash='SPU-42bae8e5d6a9304068ba1c6bbfdc18d656e287a1',
        description='Bink overlay skip', author='Zulux91', patch_version='1.0', ...)
·S ppu_loader: SPU executable hash: SPU-42bae8e5d6a9304068ba1c6bbfdc18d656e287a1 (<- 1)

AV: 0   frozen: 0   halt: 0
```

Intro cinematic plays; previously this was a permanent SPU park 1.3 ms after the Bink audio port started. Title screen reached, START advances into the cinematic, and the **main menu is reachable** (`MENÚ PRINCIPAL` / `Nueva historia`).

### Scope — what this does not claim

This patch fixes **the boot hang**, and that is all it is verified to fix. The title is not playable, and what stops it now is unrelated to this patch:

- selecting `Nueva historia` **does** reach the first mission — the cockpit renders, the objective prompt appears (`NUEVO OBJETIVO / Ve a la pista y despega`) and `Iniciar motor` is live — and the process then dies there. The cause is GPU driver memory exhaustion at the kernel level:

  ```
  [38555.528084] kgsl: out of memory: only allocated 19208Kb of 30720Kb requested   -> 05:38:07
  [39475.382976] kgsl: out of memory: only allocated  5312Kb of 30720Kb requested   -> 05:53:27
  ```

  Both correlate to the second with `ActivityManager: Process com.armsx3 ... has died: fg TOP`, and `lowmemorykiller` logged "Not killing" throughout, so this is not Android reclaiming memory from the app. The takeoff scene streams ~35 MB per frame (23 MB vertex attributes, 6.7 MB indices, 4.9 MB transform constants, ~1200 draws) against ~180 KB/frame at this title's own menu, so the data heaps grow 64 MB at a time to satisfy 41-421 KB requests until the driver refuses. Lowering `VRAM allocation limit` only changes which ceiling is hit first. Unfixed, and out of scope here.
- audio became sluggish after entering the main menu. Root-caused and fixed separately in #63: a port the game fills with silence flickers between untouched and touched (a guest write of `+0.0f` over the `-0.0f` tag flips the sign bit), which reset `untouched_expected` and cost a full untouched timeout every time, dropping the audio clock to ~55% of real time. Not a symptom of this patch.
- a separate crash exists on emulation teardown (`rsx::reports::ZCULL_control::~ZCULL_control()` → heap corruption inside `rsx::thread::~thread()`), which is pre-existing and unrelated to this patch.

So this moves BLES00928 from "hangs at the first intro video" to "boots, menus, and loads the first mission", not to Playable.

`BUNDLED_REVISION` goes 1 → 2 so existing installs re-import.

## For desktop RPCS3

The patch is not Android-specific — the YAML block above works unmodified on desktop via the Patch Manager's import button, keyed on the same SPU hash. Two observations that may be worth a core-side look there, neither of which fixes this title:

- **An SPU access violation is unrecoverable in a GUI-less build.** `Utilities/Thread.cpp:2225` sets `cpu_flag::dbg_pause`, and tree-wide it is only cleared in `GDB.cpp:827/851` (both `ppu_thread`-guarded) and `rpcs3qt/debugger_frame.cpp`. Without Qt there is no way back, so any SPU fault in any game becomes a silent permanent freeze with nothing surfaced to the user.
- **A started `cellAudio` port produces continuous loud static while emulation is in a fault state.** On this hang the Bink audio port is started 1.3 ms before the SPU dies, and what is left playing is stale guest memory. Emitting silence once emulation has faulted would be kinder. (An earlier version of this description attributed the sluggish-audio symptom to the same port being *never written*; that was wrong on measurement — the port is written, with zeros — and the real cause is fixed in #63.)


---

# Two further commits: making the bundled import safe to run

Blind adversarial review of this branch found that the change with real blast radius here is not the patch — it is the `BUNDLED_REVISION` bump. Before this PR, the boot-side patch importer only ever ran with the stored revision at 0: a first-ever boot, where `patch.yml` is empty and there is nothing to lose. The bump makes it run **once on every existing install, against a populated file**. That branch had never executed in a shipped build.

Two commits address what the review found.

## `patch_engine: stop save_patches from destroying the file it rewrites`

Two pre-existing defects on the same write path, both already reachable from *Download database* and from a local patch import — they predate the Android patch work and apply to upstream RPCS3 unchanged.

**Truncating, unchecked write.** `save_patches` opened `patch.yml` with `fs::rewrite` (`write + create + trunc`), streamed into it, discarded the write result and returned `true` unconditionally. A write that fails part way leaves a truncated file; `load()` rejects the whole file on a parse error; and `import_patches` refuses to write when `load()` fails, so both import paths then return `-1` forever with no in-app recovery. `save_config`, 70 lines up in the same file, already writes through `fs::pending_file` and checks the result — `save_patches` now does the same.

**Path-typed address elements corrupted.** The address was always emitted as `fmt::format("0x%.8x", offset)`, but for `move_file` and `hide_file` that element is a VFS path: `load()` keeps the text in `original_offset` and skips u32 validation for those two types. The emit is now gated on `patch_type_uses_hex_offset`, the predicate that already existed for this and was used only on the load side.

Measured A/B on device — same input, same device, only the emit hunk differing:

```
old:  - [move_file, 0x00000000, /dev_bdvd/PS3_GAME/USRDIR/probe.bik.bak]
      - [hide_file, 0x00000000, ""]

new:  - [move_file, /dev_bdvd/PS3_GAME/USRDIR/probe.bik, /dev_bdvd/PS3_GAME/USRDIR/probe.bik.bak]
      - [hide_file, /dev_bdvd/PS3_GAME/USRDIR/hidden.bik, ""]
```

Note the failure mode: the path is destroyed but the entry stays syntactically valid and still loads, so the patch keeps listing and toggling while silently matching nothing. Re-downloading does not repair it, because `append_patches` discards an incoming patch whose `Patch Version` is not strictly greater.

The numeric branch deliberately keeps using `offset` rather than `original_offset`: an address modifier is folded into `offset` at load time, and the flat form emitted here has nowhere to put it.

Worth being explicit about how unrecoverable the old behaviour was: once `patch.yml` is unparseable, `import_patches` refuses to write, so *Download database* and local import both return `-1` from then on; the stored revision is already advanced so the bundled path never retries; and the Patches tab has no delete, reset or clear control. Recovery meant deleting the file with an external file manager.

**Not verified:** the truncating-write failure path itself. Forcing a short write mid-rewrite (ENOSPC, or a kill inside `save_patches`) was not exercised, so atomicity is argued from `fs::pending_file`'s contract and parity with `save_config`, not from a reproduced failure.

## `Canary patches: a revision bump must not re-enable the older ones`

`ensureBundledPatches` iterated the whole `BUNDLED` list and forced every entry enabled, so bumping the revision for one game re-enabled **every** bundled patch — including the Sonic '06 Graphics Fix, for a user who had deliberately turned it off and may not even own the game the bump was made for. That contradicts the guarantee written above the function ("turning one OFF sticks").

It cannot be fixed by reading state back: `save_config` writes an entry only when it is enabled, so *disabled* is stored as an **absent** entry and `patch_config.yml` cannot distinguish opted-out from never-seen. Each `Bundled` entry now records the revision it first shipped in, and only entries newer than the stored revision are touched.

Verified on device against the upgrade-in-place shape this PR opens: stored revision 1, populated `patch.yml` without the new entry, no `patch_config.yml`. Booting a game logged

```
canary patches: imported 1, enabled 1
```

(the previous code reports `enabled 2`, since it enabled `BUNDLED.size` entries), and the resulting `patch_config.yml` contained only the H.A.W.X. entry — no Graphics Fix. The opted-out patch stayed off across the bump, the Sonic entry in `patch.yml` was preserved, and the revision advanced to 2.

Two side effects of the same change: a patch stuck failing no longer drags the settled ones back on every boot, and a bump that adds no new patch now skips the import entirely rather than rewriting `patch.yml` for no reason.

## Payload verification

The shipped patch was booted in exactly the form this PR ships:

```
·S PAT: Applied patch (hash='SPU-42bae8e5d6a9304068ba1c6bbfdc18d656e287a1',
   description='Bink overlay skip', author='Zulux91', patch_version='1.0',
   file_version='1.2') (<- 1)
```

Title screen reached, 30 fps, no SPU halt and no access violation in the session log.

## Known-open, not addressed here

- The guard (`SharedPreferences`) and the resource (emulator data root) are separate persistence domains: wiping or relocating the data folder leaves the pref saying "done", so nothing is re-imported and the game hangs again with no signal.
- The read-modify-write of `patch.yml` is unsynchronised across writers. The atomic write changes a concurrent write from *corruption* to *lost update* — a real reduction in blast radius, but it is not synchronisation and the race is not fixed.
- Lower severity: an unparseable `patch.yml` causes a silent permanent per-boot retry; editing a bundled patch's body without bumping its `Patch Version` silently no-ops while reporting success; the rewrite drops YAML comments and `Anchors`.

Nothing in the tree tests `patch_engine`, `import_patches`, or `Ps3PatchRepo`, so there is no gate that would reject a regression in any of the above. The device runs described here were performed by hand.

One caveat on the evidence: the first device run for this PR was on an install that had never downloaded the online database, so `patch.yml` held only the two canary patches. That exercised the fresh-import shape — precisely the branch where nothing can be lost — and none of the topology the two `save_patches` defects live in. The upgrade-in-place runs quoted above were added afterwards for exactly that reason.

The two `save_patches` defects are upstream RPCS3 bugs reachable without any of the Android patch work; they are worth reporting there separately.


