### PR TITLE
cellAudio: do not let an unimplemented secondary-output port stall the mixer

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -444,6 +444,15 @@ std::tuple<u32, u32, u32, u32> cell_audio_thread::count_port_buffer_tags()
 	for (audio_port& port : ports)
 	{
 		if (port.state != audio_port_state::started) continue;
+
+		// A port opened with CELL_AUDIO_PORTATTR_OUT_SECONDARY goes to a secondary output we do not
+		// implement (see the todo in cellAudioPortOpen), so its contents are discarded either way.
+		// Counting it here let it stall the whole mixer: H.A.W.X. 2 opens such a port, never writes
+		// it, and the period then waits on it every time -- measured untouched=1 in essentially
+		// every period, which drove the ringbuffer dry and collapsed the time-stretch frequency
+		// ratio to ~0.4, i.e. audible slow-down and crackling across the whole title.
+		if (port.attr & CELL_AUDIO_PORTATTR_OUT_SECONDARY) continue;
+
 		active++;
 
 		auto port_buf = port.get_vm_ptr();
@@ -904,6 +913,7 @@ void cell_audio_thread::operator()()
 
 			// Wait until buffers have been touched
 			//cellAudio.error("active=%u, in_progress=%u, untouched=%u, incomplete=%u", active_ports, in_progress, untouched, incomplete);
+
 			if (untouched > untouched_expected)
 			{
 				// Games may sometimes "skip" audio periods entirely if they're falling behind (a sort of "frameskip" for audio)


### PR DESCRIPTION
## What it does

Stops an audio port the emulator does not implement from stalling the whole mixer.

A port opened with `CELL_AUDIO_PORTATTR_OUT_SECONDARY` goes to a secondary audio output we do not support — `cellAudioPortOpen` already says so with a `todo` (`cellAudio.cpp:1314`) and the port's contents are discarded either way. But `count_port_buffer_tags` still counted it as an active port, so the mixer waited every period for a buffer that nothing would ever fill.

Found while debugging Tom Clancy's H.A.W.X. 2 (BLES00928), which opens such a port and never writes it, but nothing about the fix is specific to that title.

## Why it matters

Measured on device before the change:

```
active=2 in_progress=0 untouched=1 incomplete=0
enqueued_buffers 3..15   (swinging)
freq_ratio       0.319..0.851
```

`untouched=1` in essentially every period drove the ringbuffer dry. The time-stretcher then did what it is supposed to do about a starving buffer — it lowered the playback frequency ratio, to as little as **0.32**. Audibly that is the entire title playing slowed down, stuttering and crackling, menus included, for the whole session.

After:

```
active=1 in_progress=0 untouched=0 incomplete=0
enqueued_buffers 16..20  (stable)
freq_ratio       1.000
```

`freq_ratio` pinned at `1.000` means no stretch correction is being applied at all — the ringbuffer is being fed properly rather than being rescued.

## Verification

Confirmed by ear on device, and with **stock audio settings** — `Desired Audio Buffer Duration` back to 34 and `Enable Time Stretching` back to `false`. Both had been raised during diagnosis (100 ms / stretching on) and neither helped; the fix does not depend on either, and the numbers above are from a run with them reverted.

The measurements came from a temporary probe in the `cellAudio` period loop, next to the commented-out diagnostic already at `cellAudio.cpp:906`. That probe is not part of this PR.

## Notes

- Scope is deliberately narrow: the port is skipped only for the tag accounting that gates period advance. Nothing else about its lifetime changes, and a title that does write such a port is no worse off, since the data was already being discarded.
- Not verified: whether any title both opens a secondary port *and* depends on it gating the period. I could not construct that case, and it would have been broken already given the output is unimplemented.
