### PR TITLE
Stop two guest polling loops from flooding the log

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -876,7 +876,11 @@ error_code cellMicEnd()
 
 error_code cellMicOpenEx(s32 dev_num, s32 rawSampleRate, s32 rawChannel, s32 DSPSampleRate, s32 bufferSizeMS, u8 signalType)
 {
-	cellMic.notice("cellMicOpenEx(dev_num=%d, rawSampleRate=%d, rawChannel=%d, DSPSampleRate=%d, bufferSizeMS=%d, signalType=0x%x)",
+	// trace, not notice: titles poll this. H.A.W.X. 2 calls it ~100x/s from its HandsetEncodeThread
+	// for the whole session, and at notice level that alone was 16% of the log. cellMicOpen and
+	// cellMicOpenRaw, which are thin wrappers around this, were already trace -- so the wrappers
+	// were quieter than the function they call.
+	cellMic.trace("cellMicOpenEx(dev_num=%d, rawSampleRate=%d, rawChannel=%d, DSPSampleRate=%d, bufferSizeMS=%d, signalType=0x%x)",
 		dev_num, rawSampleRate, rawChannel, DSPSampleRate, bufferSizeMS, signalType);
 
 	auto& mic_thr = g_fxo->get<mic_thread>();

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -339,7 +339,10 @@ error_code sys_net_bnet_accept(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr>
 {
 	ppu.state += cpu_flag::wait;
 
-	sys_net.warning("sys_net_bnet_accept(s=%d, addr=*0x%x, paddrlen=*0x%x)", s, addr, paddrlen);
+	// trace, not warning: a non-blocking accept() on an idle listening socket is a normal polling
+	// pattern, not a warning. H.A.W.X. 2's cNetNode thread calls it ~200x/s for the whole session,
+	// which was 31% of the log on its own.
+	sys_net.trace("sys_net_bnet_accept(s=%d, addr=*0x%x, paddrlen=*0x%x)", s, addr, paddrlen);
 
 	if (addr.operator bool() != paddrlen.operator bool() || (paddrlen && *paddrlen < addr.size()))
 	{

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
@@ -193,7 +193,10 @@ namespace vk
 			vkGetPhysicalDeviceMemoryProperties(pdev, &memory_properties);
 			for (u32 i = 0; i < memory_properties.memoryHeapCount; ++i)
 			{
-				const u64 max_sz = (memory_properties.memoryHeaps[i].flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+				// VK_MEMORY_HEAP_DEVICE_LOCAL_BIT, not VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT: this is a
+				// heap flag, not a memory-type property. Both are 0x1 so the behaviour is unchanged,
+				// but the property enum does not belong on a VkMemoryHeap::flags test.
+				const u64 max_sz = (memory_properties.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
 					? vram_allocation_limit
 					: VK_WHOLE_SIZE;
 


### PR DESCRIPTION
## What it does

Drops two per-call guest-polling log sites from notice/warning to trace, and corrects one enum in the Vulkan allocator.

```
cellMicOpenEx        notice  -> trace     rpcs3/Emu/Cell/Modules/cellMic.cpp
sys_net_bnet_accept  warning -> trace     rpcs3/Emu/Cell/lv2/sys_net.cpp
```

Both fire once per call, unconditionally, and titles poll both.

## Why these two lines

Neither is an error condition:

- `cellMicOpen` and `cellMicOpenRaw` are thin wrappers around `cellMicOpenEx`, and both were already `trace` — the wrappers were quieter than the function they call.
- A non-blocking `accept()` on an idle listening socket is a normal polling pattern, not a warning.

`trace` keeps both available for anyone who wants them.

## What was observed

One session of Tom Clancy's H.A.W.X. 2 (BLES00928), roughly three minutes:

```
total log lines       58441
cellMicOpenEx          9353
sys_net_bnet_accept   17952
                      ~9 MB of RPCSX.log
```

After the change, the same two symbols appear 4 and 1 times, and the log for a comparable session was 2.7 MB.

**Treat these as one unreproduced observation, not a benchmark.** I did not record the census command or the per-channel log configuration for either run, I did not keep the raw logs, and `RPCSX.log` is rotated to `RPCSX.old.log` on every launch, so neither run can be re-examined. `logs::file_writer::log` also stops writing once the file reaches `avail_free / 4` (`rpcsx-android.cpp:2687`), so any line count taken from that file is a floor rather than a total. The call frequencies are guest behaviour and will differ per title and per scene.

## What follows from the source, independent of that session

These are checkable by reading the tree, and they are the part of the justification I would rely on:

**The two lines did not cost the same thing.** The logcat mirror drops a message when `int(level) > g_logcat_min_level`, which defaults to `warning` (`android/src/rpcsx-android.cpp:238`, `:284`). Severity is inverted in `logs::level` — `warning = 5`, `notice = 6` (`rpcs3/util/logs.hpp:13`). So before this change:

- `sys_net_bnet_accept` at **warning**: `5 > 5` is false, so it was **not** dropped, and each call did a synchronous `__android_log_write` to logd from the guest thread.
- `cellMicOpenEx` at **notice**: `6 > 5` is true, so it was **already** dropped from logcat and only cost buffered file bytes.

The comment block at `rpcsx-android.cpp:273-281` states the logd round trip is the expensive part and puts it at 5-7 fps for a title logging thousands of lines a second. That is about logcat mirroring in general, not a measurement of this change — but it does mean the two hunks are different in kind, and a single combined percentage would be the wrong way to describe them.

**The file write itself was not on the guest thread.** Producers `memcpy` into a 32 MiB ring (`rpcs3/util/logs.cpp:78`) drained by a dedicated low-priority writer thread; a calling thread only performs an inline flush when the ring is full (`:650-674`). At the rate observed above that does not happen, so what this removes from guest threads is the formatting and the copy — and, for the `accept` hunk only, the logd IPC.

An earlier version of this description attributed the cost to FUSE-backed storage being slow. That was wrong: the storage is behind the ring and the writer thread, not in the calling thread's path.

**No performance claim is being made here.** I have not measured frame time or stall time with and without this change, and I have not measured the two hunks separately, so which one carries what share of any improvement is unknown.

## What this gives up

`sys_net_bnet_accept`'s line was the only unconditional per-call record of that call: the stop path returns `{}` and the success path returns `not_an_error(id_ps3)`, neither of which reports. The error exits still surface through `error_code::error_report`, but that logs only the first 3 identical messages per thread (`rpcs3/Emu/Cell/ErrorCodes.cpp:82-87`), and the per-thread aggregate only fires from `thread_base::finalize`, i.e. on clean thread exit — which is not what happens on the hangs these logs usually get collected after.

So a default-level log can no longer distinguish "the title never called `accept`" from "it polled and never got a socket" from "it got a socket and the failure is downstream". Recovering that means setting the whole `sys_net` channel to trace, which also enables the per-packet sites on that channel (`sys_net.cpp:771` recvfrom, `:985` sendto, `:1257` poll, `:1433` select).

The `cellMic` hunk does not have this problem: a genuine device open still logs inside `open_microphone`, and the polling path returns `CELL_MICIN_ERROR_ALREADY_OPEN` before reaching it.

A narrower alternative exists for `accept` if reviewers prefer it — keep entry at trace and log at `notice` only on the branch that actually imports a new socket, so it fires once per real connection rather than once per poll. `RawSPUThread.cpp:46-70` also shows the rate-limiting idiom used elsewhere in the tree for this shape.

## Also included: a Vulkan enum correction

`mem_allocator_vma` tested a `VkMemoryHeap::flags` value against `VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT`, which is a memory-*type* property rather than a heap flag; the heap flag is `VK_MEMORY_HEAP_DEVICE_LOCAL_BIT`. Both constants are `0x00000001` (`3rdparty/libsdl-org/SDL/src/video/khronos/vulkan/vulkan_core.h:2357,2365`), so **behaviour is unchanged**, and `memory.cpp:274` already used the heap spelling — this removes an internal inconsistency rather than creating one. Noticed while auditing how `VRAM allocation limit (MB)` reaches VMA's `pHeapSizeLimit`.

It is unrelated to the logging change and is bundled here, which means a revert of one reverts the other. Happy to split it out if a reviewer would rather.

## Gates

Not run: no host or Android build gate, no test run. Nothing in the tree tests either symbol or the log levels, so there is no gate a regression here would fail. H.A.W.X. 2 is the only title this was observed on.
