### PR TITLE
cellAudio: don't let a silent port reset the untouched baseline every period

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -915,7 +915,7 @@ void cell_audio_thread::operator()()
 				{
 					// There's no audio in the buffers, simply advance time and hope the game recovers
 					cellAudio.trace("advancing time: untouched=%u/%u (expected=%u), enqueued_buffers=%llu", untouched, active_ports, untouched_expected, enqueued_buffers);
-					untouched_expected = untouched;
+					untouched_expected = std::min(std::max(untouched, untouched_expected), active_ports);
 					advance(timestamp);
 					continue;
 				}
@@ -931,7 +931,7 @@ void cell_audio_thread::operator()()
 				// There's no audio in the buffers, simply advance time
 				cellAudio.trace("enqueuing silence: untouched=%u/%u (expected=%u), enqueued_buffers=%llu", untouched, active_ports, untouched_expected, enqueued_buffers);
 				ringbuffer->enqueue_silence();
-				untouched_expected = untouched;
+				untouched_expected = std::min(std::max(untouched, untouched_expected), active_ports);
 				advance(timestamp);
 				continue;
 			}
@@ -946,8 +946,19 @@ void cell_audio_thread::operator()()
 
 			//cellAudio.error("active=%u, untouched=%u, in_progress=%d, incomplete=%d, enqueued_buffers=%u", active_ports, untouched, in_progress, incomplete, enqueued_buffers);
 
-			// Store number of untouched buffers for future reference
-			untouched_expected = untouched;
+			// Store number of untouched buffers for future reference.
+			//
+			// High-water mark rather than the instantaneous count, clamped to the number of
+			// active ports so that a port going away lowers it again.
+			//
+			// A game can leave a port started and write nothing but zeros into it. Those
+			// writes still overwrite the -0.0f tags with +0.0f, which flips the sign bit and
+			// makes count_port_buffer_tags() report the buffer as touched on the periods the
+			// write happens to land in. Storing the instantaneous count then drops this to 0
+			// on exactly those periods, and on the next period the very same silent port
+			// looks like a newly untouched buffer -- so the loop waits out the whole
+			// untouched timeout for it, over and over, for as long as the port exists.
+			untouched_expected = std::min(std::max(untouched, untouched_expected), active_ports);
 
 			// Log if we enqueued untouched/incomplete buffers
 			if (untouched > 0 || incomplete > 0)


### PR DESCRIPTION
## What it does

Stops a started audio port that a game fills with silence from stalling the mixer every period.

`untouched_expected` becomes a high-water mark rather than the instantaneous count, clamped to `active_ports` so a port going away lowers it again. Three assignment sites, one expression:

```cpp
untouched_expected = std::min(std::max(untouched, untouched_expected), active_ports);
```

Replaces #61, which had the same symptom but the wrong cause and the wrong fix. See the bottom of this description for what that was and why it was withdrawn.

## Root cause

A game can leave a port started and write nothing but **zeros** into it.

`audio_port::tag()` marks six slots per block with `-0.0f`, and `count_port_buffer_tags()` treats a slot as touched when the value differs — including the `-0.0f` → `+0.0f` sign flip, which it detects deliberately via `std::signbit`. A guest write of literal `0.0f` is therefore indistinguishable from real audio at those six slots. That is correct behaviour for the tag mechanism: it cannot tell silence from data, and it should not try.

The consequence is a port that reports **untouched on most periods and touched on the few a write happens to land in**. Because `untouched_expected` stored the instantaneous count, those touched periods dropped it to 0 — and on the very next period the same silent port looked like a newly untouched buffer, so the loop waited out the entire untouched timeout for it. Every time it flickered, for as long as the port existed.

The timeout that eventually released it was `partially_untouched_timeout` (4 block periods) rather than `fully_untouched_timeout` (2), because `untouched == active_ports` was never true while the other port was being written normally.

## Measurement

Tom Clancy's H.A.W.X. 2 (BLES00928), main menu, stock audio settings (time stretching **off**, buffer duration 34), on device. A temporary probe in the period loop counted branch hits per second and scanned each port's **whole block** rather than the six tag slots. Same scene, same build, only this change differing:

|                              | before        | after        |
|------------------------------|---------------|--------------|
| `wait_untouched` hits        | **669**/s     | **0**        |
| time in that wait            | 669 ms/s      | 0            |
| `MIX` (periods that mixed)   | **65**/s      | **188**/s    |
| forced `advance` (timeout)   | 37/s          | 0            |
| `enqueued_buffers`           | **0**         | 5–7          |
| `untouched > expected`       | 743/s         | 0            |
| `untouched_expected` == 0    | 799 of 875    | 0 of 376     |
| `untouched_expected` == 1    | 76 of 875     | **376 of 376** |

The last two rows are the change working as intended: the expectation now stays at 1 instead of being knocked back to 0, so the comparison that triggers the wait never fires.

Raw before/after, steady state:

```
before: timeleft=103 advance=37 wait_untouched=669 MIX=65 | enq_buf=0 gt_exp=743
        unt[0..3]=132/743/0/0 exp[0..3]=799/76/0/0
        p1 ch=2 attr=0x1 per=875 nonzero=0 maxf=0 unt=743 inprog=0 incompl=0 compl=132

after:  timeleft=188 MIX=188 | enq_buf=7 gt_exp=0
        unt[0..3]=370/6/0/0 exp[0..3]=0/376/0/0
        p1 ch=2 attr=0x1 per=376 nonzero=0 maxf=0 unt=6 inprog=0 incompl=0 compl=370
```

`nonzero=0` is the full-block scan: **zero non-zero floats out of 512, on every one of 875 consecutive periods.** That is what makes the port silent, and it is unchanged by this patch — the port is still started, still counted active, still mixed. It is the tag flicker, not the silence, that caused the stall.

## Audible effect

The audio clock ran at ~55% of real time (103 vs 189 periods per second) with the ring buffer permanently empty. The whole title sounded slowed down and stuttering, menus included.

Worth being explicit: this happened with **time stretching disabled**, and `frequency_ratio` stayed at `1.000` for the entire session. The slowdown is the period advance rate itself, not resampling. Confirmed by ear before and after.

## Scope and risk

- The fix does not read `port.attr`, does not skip any port, and does not change what is mixed. A title whose only started port is silent is unaffected in what it hears — the port is still counted and still mixed.
- `enqueue_silence()` fast paths are untouched.
- Regression check on a second title: Plants vs. Zombies (BLUS30852) boots with the audio backend opening normally (Oboe, 48000 Hz, stereo) and audio confirmed correct by ear.
- **Not verified:** whether any title depends on `untouched_expected` falling *back* to a lower value within a stable port configuration. The clamp to `active_ports` handles ports going away, but a game that legitimately reduces how many buffers it leaves untouched will now keep the higher expectation until a port closes. I could not construct a case where that matters, and I am flagging it rather than claiming it is impossible.
- Nothing in the tree tests this loop, so no gate would reject a regression here.

## Why #61 was withdrawn

#61 excluded ports carrying `CELL_AUDIO_PORTATTR_OUT_SECONDARY` from the tag accounting, on the reasoning that such a port goes to an unimplemented output and its contents are discarded anyway.

Blind review found, and I confirmed against source, that this was wrong on its own premise:

- `mix()` iterates started ports with no attribute filter, so the port was still summed into the primary output — the "discarded either way" claim was false.
- Five sites iterate started ports; the filter was added to one.
- A title whose only started port carried that bit would hit `active_ports == 0` and play **complete silence**.
- `CELL_AUDIO_PORTATTR_OUT_SECONDARY` and `CELL_AUDIO_PORTATTR_OUT_STREAM1` are both `0x1`, so the guard's real scope was wider than its name.
- The supporting evidence was also weak: the `untouched` counter compares 6 of 512 floats, so it never established that the port was unwritten. The full-block scan here does, and shows the port *is* written — with zeros.

The measurement in #61 was additionally unsound: the `frequency_ratio 0.319..0.851` figures came from a run with time stretching **enabled**, compared against an "after" run with it disabled, where `1.000` is true by construction. Two different experiments presented as one.
